### PR TITLE
feat: 内置企业微信(WeCom)分身规则并更新 README 文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The native macOS desktop interface provides a visual, streamlined experience:
    - Automatically matches built-in recipes or runs the App Prober on unlisted applications.
    - Customize clone name, display title, custom icon, dedicated data directory (e.g. on external SSDs), and independent HTTP / SOCKS5 proxies.
 3. **Built-in Recipe Library**:
-   - Explore 32+ pre-configured application recipes (WeChat, QQ, Chrome, Cursor, ChatGPT, Claude, etc.) categorized by type, complete with sandbox stripping rules and isolation strategies.
+   - Explore 33+ pre-configured application recipes (WeChat, QQ, Chrome, Cursor, ChatGPT, Claude, etc.) categorized by type, complete with sandbox stripping rules and isolation strategies.
 4. **App Prober (Deep Architecture Inspection)**:
    - Inspect any unknown macOS app's Mach-O architecture, frameworks, and sandbox entitlements, and generate custom recipe YAML files with one click.
 5. **System Diagnostics (Doctor)**:
@@ -274,6 +274,7 @@ atbclone --version
 | Category | Application | Bundle Identifier | Strategy | App Type | Strip Sandbox |
 | :--- | :--- | :--- | :--- | :--- | :---: |
 | **Instant Messaging & Collaboration** | WeChat | `com.tencent.xinWeChat` | Hard Clone | `cocoa` | ✔ |
+| | WeCom (企业微信) | `com.tencent.WeWorkMac` | Hard Clone | `chromium` | ✔ |
 | | QQ | `com.tencent.qq` | Hard Clone | `electron` | ✔ |
 | | Lark (飞书) | `com.electron.lark` | Hard Clone | `electron` | ✔ |
 | | Telegram (Native Swift) | `ru.keepcoder.Telegram` | Hard Clone | `cocoa` | ✔ |
@@ -305,10 +306,6 @@ atbclone --version
 | | VS Code | `com.microsoft.VSCode` | Soft Clone | `electron` | — |
 | | Android Studio | `com.google.android.studio` | Hard Clone | `generic` | ✔ |
 | | Zed | `dev.zed.Zed` | Soft Clone | `generic` | — |
-
-> [!WARNING]
-> **Regarding WeCom (企业微信 / `com.tencent.WeWorkMac`)**:
-> Due to proprietary Chromium Embedded Framework (CEF) sub-process architecture, deep Seatbelt sandbox enforcement, and multi-layered process singleton checks, WeCom cannot currently be cloned reliably. ATBClone does not support WeCom cloning at this time.
 
 ---
 

--- a/Readme_zh.md
+++ b/Readme_zh.md
@@ -61,7 +61,7 @@ macOS 原生桌面图形客户端提供直观、全功能的应用分身管理�
    - 自动匹配内置规则或动态触发深度架构探测。
    - 可视化自定义分身名称、显示标题、独立数据目录（如外接移动硬盘）以及 HTTP/SOCKS5 专属代理配置。
 3. **内置规则库 (Recipe Library)**：
-   - 分类浏览内置的 32+ 热门应用规则（微信、QQ、Chrome、Cursor、ChatGPT、Claude 等），查看沙盒剥离与隔离策略。
+   - 分类浏览内置的 33+ 热门应用规则（微信、QQ、Chrome、Cursor、ChatGPT、Claude 等），查看沙盒剥离与隔离策略。
 4. **应用深度探测器 (App Prober)**：
    - 可视化检测任意未知应用的 Mach-O 架构、Frameworks 与沙盒权限，一键生成专属分身规则。
 5. **系统健康自检 (Doctor)**：
@@ -274,6 +274,7 @@ atbclone --version
 | 类别 | 应用名称 | Bundle Identifier | 克隆策略 | 应用类型 (App Type) | 沙盒解除 (Strip Sandbox) |
 | :--- | :--- | :--- | :--- | :--- | :---: |
 | **即时通讯 & 协同办公** | 微信 (WeChat) | `com.tencent.xinWeChat` | Hard Clone | `cocoa` | ✔ |
+| | 企业微信 (WeCom) | `com.tencent.WeWorkMac` | Hard Clone | `chromium` | ✔ |
 | | QQ | `com.tencent.qq` | Hard Clone | `electron` | ✔ |
 | | 飞书 (Lark) | `com.electron.lark` | Hard Clone | `electron` | ✔ |
 | | Telegram (原生 Swift) | `ru.keepcoder.Telegram` | Hard Clone | `cocoa` | ✔ |
@@ -305,10 +306,6 @@ atbclone --version
 | | VS Code | `com.microsoft.VSCode` | Soft Clone | `electron` | — |
 | | Android Studio | `com.google.android.studio` | Hard Clone | `generic` | ✔ |
 | | Zed | `dev.zed.Zed` | Soft Clone | `generic` | — |
-
-> [!WARNING]
-> **关于企业微信 (WeCom / `com.tencent.WeWorkMac`)**：
-> 由于企业微信客户端深度集成了定制版 CEF (Chromium Embedded Framework) 多进程架构与强绑定的 Seatbelt / Helper 子进程沙盒校验机制，目前在 macOS 上无法实现无损独立分身，ATBClone 暂不支持企业微信的多开分身。
 
 ---
 

--- a/src/atbclone/recipes/builtin/com.tencent.WeWorkMac.yaml
+++ b/src/atbclone/recipes/builtin/com.tencent.WeWorkMac.yaml
@@ -1,0 +1,11 @@
+bundle_id: com.tencent.WeWorkMac
+app_name: 企业微信
+strategy: hard_clone
+app_type: chromium
+strip_sandbox: true
+injection_strategy: dylib
+environment_injection:
+  HOME: '{{ATB_DATA_DIR}}/Home'
+  TMPDIR: '{{ATB_DATA_DIR}}/Tmp'
+symlink_whitelist:
+- Library/Keychains

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -202,6 +202,21 @@ def test_load_builtin_qq():
     assert "TMPDIR" in recipe.environment_injection
 
 
+def test_load_builtin_wework(monkeypatch, tmp_path):
+    monkeypatch.setattr(RecipeLoader, "LOCAL_DIR", tmp_path)
+    recipe = RecipeLoader.match("com.tencent.WeWorkMac")
+    assert recipe is not None
+    assert recipe.bundle_id == "com.tencent.WeWorkMac"
+    assert recipe.app_name == "企业微信"
+    assert recipe.strategy == "hard_clone"
+    assert recipe.app_type == "chromium"
+    assert recipe.strip_sandbox is True
+    assert recipe.injection_strategy == "dylib"
+    assert "HOME" in recipe.environment_injection
+    assert "TMPDIR" in recipe.environment_injection
+    assert "Library/Keychains" in recipe.symlink_whitelist
+
+
 def test_load_builtin_chatgpt():
     recipe = RecipeLoader.match("com.openai.codex")
     assert recipe is not None
@@ -301,6 +316,7 @@ def test_all_builtin_recipes_valid(monkeypatch, tmp_path):
 
     expected_recipes = {
         "com.tencent.xinWeChat": ("微信", "hard_clone", True),
+        "com.tencent.WeWorkMac": ("企业微信", "hard_clone", True),
         "com.google.Chrome": ("Chrome", "hard_clone", False),
         "com.tencent.qq": ("QQ", "hard_clone", True),
         "ru.keepcoder.Telegram": ("Telegram", "hard_clone", True),


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the problem and the proposed solution. -->

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring / Documentation / CI improvement

## Environment Information
- **OS**: macOS [e.g. macOS 14 / 15]
- **Architecture**: [e.g. Apple Silicon (arm64) / Intel (x86_64)]
- **Python Version**: Python 3.12+

## Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have run full test suite locally: `PYTHONPATH=src conda run -n ATBClone python -m pytest tests/` and all tests pass.
- [x] I have verified no regressions were introduced to existing clone engines or GUI views.
- [x] Any new or modified functionality includes corresponding tests.
- [x] PR title follows conventional commit format (e.g., `feat: ...`, `fix: ...`, `ci: ...`).

## Author / Agent Environment Disclosure
<!-- If authored with the assistance of an AI agent, disclose the model, harness, and version. Otherwise state handwritten. -->
- **Authoring**: [Handwritten / AI-assisted]
- **Environment**: [e.g. Model, Harness, or N/A]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a built-in recipe for WeCom (企业微信) on macOS, supporting hard cloning for its Chromium-based application.
  - Configured the recipe to support required environment settings, library keychain handling, and sandbox stripping.

- **Documentation**
  - Updated the English and Chinese documentation to list 33+ built-in recipes.
  - Added WeCom to the Instant Messaging & Collaboration recipe tables and removed the previous cloning limitation notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->