### PR TITLE
feat(wemeet): Tencent Meeting dual-lock isolation for N instances

### DIFF
--- a/src/atbclone/core/engines.py
+++ b/src/atbclone/core/engines.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import os
+import re
 import shlex
 import struct
 import textwrap
@@ -1037,6 +1038,182 @@ CHATGPT_HOOK_EOF
             chmod +x {dst_frameworks}/libatbclone_chatgpt_hook.dylib
         """).strip() + "\n"
 
+    # Tencent Meeting (Wemeet) dual global locks, verified on 3.45.3:
+    #   lock 1: MD5("com.tencent.wemeet.WemeetLauncher")
+    #           -> /tmp/baab259e9d9912ee7e2d6daf05db5829
+    #   lock 2: MD5("com.tencent.meeting")
+    #           -> /tmp/d3f3c61c93ee6f6463feed44a4cd5673
+    # Both paths are hardcoded and ignore the per-clone HOME/TMPDIR, so
+    # every clone (and the main app) flock()s the same /tmp files and the
+    # loser forwards to the running instance via SendMessage and exits(2).
+    # Per-clone fix: same-length tail-char replacement in Mach-O binaries
+    # only (never plist/nib/CodeResources):
+    #   "WemeetLauncher" (14B) -> "WemeetLauncheX"
+    #   "com.tencent.meeting" (19B) -> "com.tencent.meetinX"
+    # where X is one slot char derived from the clone number. Distinct X
+    # per clone yields distinct MD5s and hence distinct lock files plus
+    # distinct Mach service names.
+    WEMEET_BUNDLE_IDS = ("com.tencent.meeting", "com.tencent.wemeet")
+    _WEMEET_LAUNCHER_NEEDLE = b"WemeetLauncher"
+    _WEMEET_BUNDLE_NEEDLE = b"com.tencent.meeting"
+    _WEMEET_SLOT_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+    @classmethod
+    def _wemeet_slot_for_task(cls, task: CloneTask) -> str:
+        """Derive a single per-clone slot char from the clone number.
+
+        Prefers the trailing digits of new_bundle_id ("...atbclone.N"),
+        falls back to the trailing digits of clone_name, then 1. The number
+        is mapped through a 36-char alphabet so multi-digit numbers still
+        fit the single-char same-length replacement budget.
+        """
+        num = 1
+        for candidate in (
+            getattr(task, "new_bundle_id", "") or "",
+            getattr(task, "clone_name", "") or "",
+        ):
+            match = re.search(r"(\d+)$", candidate.strip())
+            if match:
+                try:
+                    num = int(match.group(1))
+                except ValueError:
+                    continue
+                break
+        try:
+            slot_index = int(num) % len(cls._WEMEET_SLOT_ALPHABET)
+        except (TypeError, ValueError):
+            slot_index = 1
+        return cls._WEMEET_SLOT_ALPHABET[slot_index]
+
+    @staticmethod
+    def _is_wemeet_task(task: CloneTask) -> bool:
+        """Return True when the task targets Tencent Meeting (either bundle id)."""
+        bundle_ids = HardCloneEngine.WEMEET_BUNDLE_IDS
+        return bool(
+            getattr(task.recipe, "patch_wemeet_isolation", False)
+            or getattr(task.source, "bundle_id", "") in bundle_ids
+            or getattr(task.recipe, "bundle_id", "") in bundle_ids
+            or any(
+                (getattr(task, "new_bundle_id", "") or "").startswith(bid)
+                for bid in bundle_ids
+            )
+        )
+
+    @classmethod
+    def patch_wemeet_locks(cls, dest_path: Path, slot: str) -> bool:
+        """Python helper: per-clone same-length lock-string replacement.
+
+        Walks dest_path/Contents for Mach-O binaries and replaces the two
+        hardcoded lock strings with slot-suffixed variants. Returns True if
+        at least one file was patched. Skips symlinks and non-Mach-O files
+        (plist/nib/CodeResources are never touched).
+        """
+        if not slot or len(slot) != 1:
+            return False
+        launcher_replacement = b"WemeetLaunche" + slot.encode("ascii", "ignore")
+        bundle_replacement = b"com.tencent.meetin" + slot.encode("ascii", "ignore")
+        if len(launcher_replacement) != len(cls._WEMEET_LAUNCHER_NEEDLE):
+            return False
+        if len(bundle_replacement) != len(cls._WEMEET_BUNDLE_NEEDLE):
+            return False
+
+        contents_dir = Path(dest_path) / "Contents"
+        if not contents_dir.is_dir():
+            return False
+
+        patched_any = False
+        for root, _, files in os.walk(contents_dir):
+            for fname in files:
+                fpath = Path(root) / fname
+                if fpath.is_symlink() or not fpath.is_file():
+                    continue
+                try:
+                    with open(fpath, "rb") as fp:
+                        header = fp.read(4)
+                    if header not in (b"\xcf\xfa\xed\xfe", b"\xfe\xed\xfa\xcf"):
+                        continue
+                    with open(fpath, "rb") as fp:
+                        data = bytearray(fp.read())
+                    changed = False
+                    if cls._WEMEET_LAUNCHER_NEEDLE in data:
+                        data = bytearray(
+                            data.replace(
+                                cls._WEMEET_LAUNCHER_NEEDLE, launcher_replacement
+                            )
+                        )
+                        changed = True
+                    if cls._WEMEET_BUNDLE_NEEDLE in data:
+                        data = bytearray(
+                            data.replace(cls._WEMEET_BUNDLE_NEEDLE, bundle_replacement)
+                        )
+                        changed = True
+                    if changed:
+                        with open(fpath, "wb") as fp:
+                            fp.write(data)
+                        patched_any = True
+                except (OSError, ValueError):
+                    continue
+        return patched_any
+
+    @classmethod
+    def _build_wemeet_isolation_cmd(cls, task: CloneTask) -> str:
+        """Return a shell snippet that per-clone patches the Wemeet dual locks.
+
+        Only Mach-O binaries under Contents are rewritten; plist/nib/
+        CodeResources files are skipped. Runs before codesign in the clone
+        script. Also strips CFBundleURLTypes so clones stop activating each
+        other via the shared wemeet:// scheme.
+        """
+        if not cls._is_wemeet_task(task):
+            return ""
+        slot = cls._wemeet_slot_for_task(task)
+        rel_plist = getattr(task.source, "relative_plist_path", Path("Contents/Info.plist"))
+        dst_plist = shlex.quote(str(task.dest_path / rel_plist))
+        # Double-quoted Python literal (the surrounding `python3 -c '...'` is
+        # single-quoted, so double quotes are shell-safe; macOS paths contain
+        # no double quotes after this escape).
+        dst_py = str(task.dest_path).replace("\\", "\\\\").replace('"', '\\"')
+        strip_schemes_cmd = ""
+        if getattr(task.recipe, "strip_url_schemes", False) or True:
+            strip_schemes_cmd = f'/usr/libexec/PlistBuddy -c "Delete :CFBundleURLTypes" {dst_plist} 2>/dev/null || true\n'
+        return textwrap.dedent(f"""\
+            # Wemeet isolation: per-clone lock strings (slot {slot}) + strip URL schemes
+            {strip_schemes_cmd}python3 -c '
+import os
+dst = "{dst_py}"
+slot = "{slot}"
+launcher_old = b"WemeetLauncher"
+launcher_new = b"WemeetLaunche" + slot.encode("ascii")
+bundle_old = b"com.tencent.meeting"
+bundle_new = b"com.tencent.meetin" + slot.encode("ascii")
+contents = os.path.join(dst, "Contents")
+if os.path.isdir(contents):
+    for root, _, files in os.walk(contents):
+        for fname in files:
+            fpath = os.path.join(root, fname)
+            if os.path.islink(fpath) or not os.path.isfile(fpath):
+                continue
+            try:
+                with open(fpath, "rb") as f:
+                    if f.read(4) not in (b"\\xcf\\xfa\\xed\\xfe", b"\\xfe\\xed\\xfa\\xcf"):
+                        continue
+                    f.seek(0)
+                    data = bytearray(f.read())
+                changed = False
+                if launcher_old in data:
+                    data = bytearray(data.replace(launcher_old, launcher_new))
+                    changed = True
+                if bundle_old in data:
+                    data = bytearray(data.replace(bundle_old, bundle_new))
+                    changed = True
+                if changed:
+                    with open(fpath, "wb") as f:
+                        f.write(data)
+            except Exception:
+                pass
+' 2>/dev/null || true
+        """)
+
     @staticmethod
     def _build_symlink_whitelist_snippet(task: CloneTask) -> str:
         """Return a shell snippet that creates symlinks for items in symlink_whitelist."""
@@ -1354,13 +1531,15 @@ CHATGPT_HOOK_EOF
             or getattr(task, "new_bundle_id", "").startswith("com.openai.codex")
             or getattr(task, "new_bundle_id", "").startswith("com.openai.chat")
         )
+        is_wemeet = cls._is_wemeet_task(task)
 
         # Build framework singleton patcher command ONLY when explicitly enabled by recipe
-        # and NOT for Feishu/Lark or ChatGPT which use dedicated Cocoa/POSIX hook isolation.
+        # and NOT for Feishu/Lark, ChatGPT or Wemeet which use dedicated isolation.
         needs_singleton_patch = (
             getattr(task.recipe, "patch_framework_singleton", False)
             and not is_lark
             and not is_chatgpt
+            and not is_wemeet
         )
         singleton_patch_cmd = (
             cls._build_singleton_patch_cmd(task.dest_path)
@@ -1387,6 +1566,13 @@ CHATGPT_HOOK_EOF
         chatgpt_isolation_cmd = (
             cls._build_chatgpt_isolation_cmd(task)
             if is_chatgpt
+            else ""
+        )
+
+        # Build Wemeet isolation command ONLY when cloning Tencent Meeting
+        wemeet_isolation_cmd = (
+            cls._build_wemeet_isolation_cmd(task)
+            if is_wemeet
             else ""
         )
 
@@ -1478,7 +1664,7 @@ chmod -R u+w {dst} 2>/dev/null || true
 {icon_cmd}{exec_prep_cmd}
 {pref_seeding}
 {symlink_snippet}
-{singleton_patch_cmd}{cef_patch_cmd}{lark_isolation_cmd}{chatgpt_isolation_cmd}{framework_prune_cmd}xattr -cr {dst} 2>/dev/null || true
+{singleton_patch_cmd}{cef_patch_cmd}{lark_isolation_cmd}{chatgpt_isolation_cmd}{wemeet_isolation_cmd}{framework_prune_cmd}xattr -cr {dst} 2>/dev/null || true
 {codesign_cmds}codesign -vv --deep --strict {dst}
 {lsregister_cmd}
 """

--- a/src/atbclone/recipes/builtin/com.tencent.meeting.yaml
+++ b/src/atbclone/recipes/builtin/com.tencent.meeting.yaml
@@ -1,0 +1,12 @@
+bundle_id: com.tencent.meeting
+app_name: 腾讯会议
+strategy: hard_clone
+app_type: cocoa
+strip_sandbox: true
+patch_wemeet_isolation: true
+strip_url_schemes: true
+environment_injection:
+  HOME: '{{ATB_DATA_DIR}}/Home'
+  TMPDIR: '{{ATB_DATA_DIR}}/Tmp'
+symlink_whitelist:
+- Library/Keychains

--- a/src/atbclone/recipes/builtin/com.tencent.wemeet.yaml
+++ b/src/atbclone/recipes/builtin/com.tencent.wemeet.yaml
@@ -1,0 +1,12 @@
+bundle_id: com.tencent.wemeet
+app_name: 腾讯会议
+strategy: hard_clone
+app_type: cocoa
+strip_sandbox: true
+patch_wemeet_isolation: true
+strip_url_schemes: true
+environment_injection:
+  HOME: '{{ATB_DATA_DIR}}/Home'
+  TMPDIR: '{{ATB_DATA_DIR}}/Tmp'
+symlink_whitelist:
+- Library/Keychains

--- a/src/atbclone/recipes/models.py
+++ b/src/atbclone/recipes/models.py
@@ -96,6 +96,7 @@ class Recipe(BaseModel):
     patch_cef: bool = False
     patch_lark_isolation: bool = False
     patch_chatgpt_isolation: bool = False
+    patch_wemeet_isolation: bool = False
     strip_url_schemes: bool = False
     injection_strategy: InjectionStrategy = "auto"
 

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -833,6 +833,94 @@ class TestProcessSingletonFrameworkPatching:
             assert "Patch ProcessSingleton in embedded frameworks" in script
 
 
+class TestWemeetIsolation:
+    """Tests for Tencent Meeting dual-lock isolation (verified on 3.45.3).
+
+    Root cause: two hardcoded global locks ignore HOME/TMPDIR --
+      lock 1: MD5("com.tencent.wemeet.WemeetLauncher") -> /tmp/baab259e...
+      lock 2: MD5("com.tencent.meeting") -> /tmp/d3f3c61c...
+    Losers forward via SendMessage and exit(2). Fix: same-length tail-char
+    replacement per clone in Mach-O binaries only.
+    """
+
+    def test_wemeet_slot_from_bundle_id(self, sample_task):
+        sample_task.new_bundle_id = "com.tencent.meeting.atbclone.4"
+        sample_task.clone_name = "TencentMeeting4"
+        assert HardCloneEngine._wemeet_slot_for_task(sample_task) == "4"
+
+    def test_wemeet_slot_falls_back_to_clone_name(self, sample_task):
+        sample_task.new_bundle_id = "com.tencent.meeting.atbclone.X"
+        sample_task.clone_name = "TencentMeeting6"
+        assert HardCloneEngine._wemeet_slot_for_task(sample_task) == "6"
+
+    def test_wemeet_slot_multidigit_stays_single_char(self, sample_task):
+        sample_task.new_bundle_id = "com.tencent.meeting.atbclone.12"
+        sample_task.clone_name = "TencentMeeting12"
+        slot = HardCloneEngine._wemeet_slot_for_task(sample_task)
+        assert len(slot) == 1 and slot in HardCloneEngine._WEMEET_SLOT_ALPHABET
+
+    def test_patch_wemeet_locks_rewrites_macho_only(self, tmp_path):
+        app_dir = tmp_path / "TencentMeeting4.app"
+        macos_dir = app_dir / "Contents" / "MacOS"
+        macos_dir.mkdir(parents=True)
+        macho = macos_dir / "TencentMeeting"
+        payload = (
+            b"\xcf\xfa\xed\xfe"
+            + b"\x00" * 64
+            + b"lock:com.tencent.wemeet.WemeetLauncher|bid:com.tencent.meeting|end"
+        )
+        macho.write_bytes(payload)
+        # Non-Mach-O decoys must stay untouched.
+        plist = app_dir / "Contents" / "Info.plist"
+        plist.write_bytes(b"com.tencent.meeting.atbclone.4 WemeetLauncher")
+        nib = macos_dir / "view.nib"
+        nib.write_bytes(b"WemeetLauncher com.tencent.meeting")
+
+        assert HardCloneEngine.patch_wemeet_locks(app_dir, "4") is True
+        patched = macho.read_bytes()
+        assert b"WemeetLauncher" not in patched
+        assert b"WemeetLaunche4" in patched
+        assert b"com.tencent.meeting" not in patched
+        assert b"com.tencent.meetin4" in patched
+        # Same-length guarantee keeps Mach-O offsets stable.
+        assert len(patched) == len(payload)
+        assert plist.read_bytes().find(b"WemeetLauncher") != -1
+        assert nib.read_bytes().find(b"com.tencent.meeting") != -1
+
+    def test_patch_wemeet_locks_no_contents(self, tmp_path):
+        assert HardCloneEngine.patch_wemeet_locks(tmp_path / "Empty.app", "2") is False
+
+    def test_hard_clone_script_includes_wemeet_isolation(self, sample_task):
+        sample_task.source.bundle_id = "com.tencent.meeting"
+        sample_task.new_bundle_id = "com.tencent.meeting.atbclone.4"
+        sample_task.clone_name = "TencentMeeting4"
+        with patch("atbclone.executor.runner.Runner.run") as mock_run:
+            HardCloneEngine.execute(sample_task, needs_admin=False)
+            script, _ = mock_run.call_args[0]
+            assert "Wemeet isolation" in script
+            assert "WemeetLaunche" in script
+            assert "com.tencent.meetin" in script
+            assert "Delete :CFBundleURLTypes" in script
+            assert "Patch ProcessSingleton in embedded frameworks" not in script
+
+    def test_hard_clone_script_includes_wemeet_for_legacy_id(self, sample_task):
+        sample_task.source.bundle_id = "com.tencent.wemeet"
+        sample_task.new_bundle_id = "com.tencent.wemeet.atbclone.2"
+        sample_task.clone_name = "TencentMeeting2"
+        with patch("atbclone.executor.runner.Runner.run") as mock_run:
+            HardCloneEngine.execute(sample_task, needs_admin=False)
+            script, _ = mock_run.call_args[0]
+            assert "Wemeet isolation" in script
+
+    def test_hard_clone_script_omits_wemeet_for_other_apps(self, sample_task):
+        sample_task.source.bundle_id = "com.google.Chrome"
+        sample_task.recipe.patch_wemeet_isolation = False
+        with patch("atbclone.executor.runner.Runner.run") as mock_run:
+            HardCloneEngine.execute(sample_task, needs_admin=False)
+            script, _ = mock_run.call_args[0]
+            assert "Wemeet isolation" not in script
+
+
 class TestCefFrameworkPatchingAndSymlinks:
     """Tests for Chromium Embedded Framework (CEF) patch gating and symlink whitelist generation."""
 


### PR DESCRIPTION
## 背景（实测 3.45.3，bundle com.tencent.meeting）

腾讯会议把两把单例锁写死，不走分身的 HOME/TMPDIR 隔离：

- 锁1：MD5("com.tencent.wemeet.WemeetLauncher") -> /tmp/baab259e9d9912ee7e2d6daf05db5829（lock_name 同名，用于 flock + SendMessage 转发）
- 锁2：MD5("com.tencent.meeting") -> /tmp/d3f3c61c93ee6f6463feed44a4cd5673（硬编码原包名，不读分身 plist 的 atbclone.N）

现象：终端直跑分身报 `flock failed: 35 ... SendMessage result: 1` 后 `exit:2`，只能主+任意一个运行，第3个起闪开闪关。MD5 已验证：MD5(com.tencent.wemeet.WemeetLauncher) 与日志 lock path 完全一致。

## 改动

- `Recipe` 新增 `patch_wemeet_isolation` 开关（默认关，与 lark/chatgpt 开关并列）
- `HardCloneEngine` 新增 `_wemeet_slot_for_task` / `_is_wemeet_task` / `patch_wemeet_locks` / `_build_wemeet_isolation_cmd`：按分身编号取单字符 slot（bundle 尾号优先，36 进制保单字符），对 Contents 下 Mach-O 二进制做等长替换 `WemeetLauncher->WemeetLauncheX`、`com.tencent.meeting->com.tencent.meetinX`（跳过 plist/nib/CodeResources/软链，长度不变保 Mach-O 偏移），附带删 `CFBundleURLTypes` 防 wemeet:// 互唤；拼进 hard clone 脚本 codesign 之前；singleton 互斥排除 wemeet
- 新增内置配方 `com.tencent.meeting.yaml` + `com.tencent.wemeet.yaml`（hard_clone/cocoa/strip_sandbox/开 wemeet 隔离+去 URL scheme/HOME+TMPDIR）
- `tests/test_engines.py` 新增 `TestWemeetIsolation` 8 个单测（slot 推导/仅 Mach-O 改写/脚本门控/legacy id/互斥）

## 验证

- 新增 8 单测全过；`test_recipes` 全过；`test_engines` 失败集与上游 main 逐项一致（29 个 Windows 环境预置失败，无新增回归）
- 真机：5 个分身按 slot 改完后 lock path 变为各自分 MD5，无 flock failed，主+5 共存
- 内嵌 python 经 compile 校验；复用既有 codesign/lsregister 流程


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added built-in hard-cloning support for Tencent Meeting and Tencent Wemeet.
  - Each clone now receives isolated lock files and macOS service names to help multiple clones run independently.
  - Clone-specific home and temporary directories are configured automatically, with keychain access preserved.
  - URL scheme handling is adjusted for cloned Tencent Meeting apps.
- **Configuration**
  - Added an option to enable Tencent Meeting isolation patching for compatible recipes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->