### PR TITLE
feat: 添加 KakaoTalk 内置分身规则

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ src/atbclone/
 │   └── views/            # GUI views (dashboard, recipes, probe, doctor, settings, logs)
 ├── executor/             # Low-level executors (Subprocess / AppleScript elevation)
 │   └── runner.py
-└── recipes/              # Recipe models, loaders & 33 built-in rules
+└── recipes/              # Recipe models, loaders & 34 built-in rules
     ├── builtin/          # Built-in YAML recipes
     ├── loader.py         # Recipe matching & priority loader
     └── models.py         # Pydantic validation models

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ATBClone provides two distribution packages with **identical core functionality*
   - **Soft Clone**: Designed for modern code editors and browsers (Cursor, VS Code, Firefox, Brave, Tor, Zed, etc.). Generates a lightweight wrapper bundle, automatically injecting isolated `--user-data-dir` / `--profile` launch arguments and proxy environment variables.
 - 🔍 **Intelligent App Prober**: Automatically inspects Mach-O architectures, frameworks, and code signing sandbox entitlements for any application without a pre-configured recipe, dynamically determining the optimal soft/hard clone strategy and generating recommended recipes.
 - 🌐 **Isolated Network Proxies**: Configure dedicated HTTP or SOCKS5 proxies (with authentication support) per cloned application without interfering with host system or primary application traffic.
-- 📑 **Recipe Engine**: 33+ built-in recipes for popular apps and AI Agent tools, with local override support via `~/ATBClone/recipes/`.
+- 📑 **Recipe Engine**: 34+ built-in recipes for popular apps and AI Agent tools, with local override support via `~/ATBClone/recipes/`.
 - 🪄 **Interactive Wizard**: Step-by-step interactive CLI guide supporting terminal drag-and-drop application paths, automatic name incrementing, custom data directory configuration, and on-the-fly proxy setup.
 - 🔄 **Lifecycle Management**: View cloned apps (`list`), re-clone after primary app updates while preserving user and chat data (`update`), and safely remove clones with interactive prompts or flag controls (`remove` with `--with-data` / `--keep-data`).
 - 🛡️ **Security & Privilege Elevation**: Writing to `~/ATBClone/Apps` requires no admin privileges; writing to `/Applications` uses native single-prompt macOS `osascript` authorization; robust path escaping via `shlex.quote` throughout.
@@ -60,7 +60,7 @@ The native macOS desktop interface provides a visual, streamlined experience:
    - Automatically matches built-in recipes or runs the App Prober on unlisted applications.
    - Customize clone name, display title, custom icon, dedicated data directory (e.g. on external SSDs), and independent HTTP / SOCKS5 proxies.
 3. **Built-in Recipe Library**:
-   - Explore 33+ pre-configured application recipes (WeChat, QQ, Chrome, Cursor, ChatGPT, Claude, etc.) categorized by type, complete with sandbox stripping rules and isolation strategies.
+   - Explore 34+ pre-configured application recipes (WeChat, QQ, Chrome, Cursor, ChatGPT, Claude, etc.) categorized by type, complete with sandbox stripping rules and isolation strategies.
 4. **App Prober (Deep Architecture Inspection)**:
    - Inspect any unknown macOS app's Mach-O architecture, frameworks, and sandbox entitlements, and generate custom recipe YAML files with one click.
 5. **System Diagnostics (Doctor)**:
@@ -282,6 +282,7 @@ atbclone --version
 | | Telegram (Native Swift) | `ru.keepcoder.Telegram` | Hard Clone | `cocoa` | ✔ |
 | | Telegram Desktop | `org.telegram.desktop` | Hard Clone | `generic` | ✔ |
 | | LINE | `jp.naver.line.mac` | Hard Clone | `cocoa` | ✔ |
+| | KakaoTalk | `com.kakao.KakaoTalkMac` | Hard Clone | `cocoa` | ✔ |
 | | Slack | `com.tinyspeck.slackmacgap` | Hard Clone | `electron` | ✔ |
 | | Discord | `com.hnc.Discord` | Hard Clone | `electron` | ✔ |
 | | Skype | `com.skype.skype` | Hard Clone | `electron` | ✔ |
@@ -308,6 +309,8 @@ atbclone --version
 | | VS Code | `com.microsoft.VSCode` | Soft Clone | `electron` | — |
 | | Android Studio | `com.google.android.studio` | Hard Clone | `generic` | ✔ |
 | | Zed | `dev.zed.Zed` | Soft Clone | `generic` | — |
+
+**KakaoTalk validation:** Concurrent launch with the original app and notifications have been checked. Clone login, separate-account data isolation, and login persistence after restarting the clone have not yet been verified.
 
 ---
 

--- a/Readme_zh.md
+++ b/Readme_zh.md
@@ -39,7 +39,7 @@ Release 页面主要提供两个发布文件，**核心功能完全一致**：
   - **软克隆 (Soft Clone)**：面向现代代码编辑器与浏览器（Cursor、VS Code、Firefox、Brave、Tor、Zed 等）。生成轻量级启动器包装（Wrapper Bundle），自动注入 `--user-data-dir` / `--profile` 参数与独立代理环境变量。
 - 🔍 **智能应用探测 (App Prober)**：遇到未预设规则的任意 macOS 应用程序时，自动分析其 Mach-O 架构、Frameworks 与代码签名沙盒权限，动态决定软/硬克隆策略并提取推荐规则。
 - 🌐 **独立网络代理 (Isolated Network Proxies)**：为每个分身实例配置独立的 HTTP 或 SOCKS5 代理（支持认证），与系统主网络及母体应用互不干扰。
-- 📑 **规则引擎 (Recipe Engine)**：内置 33+ 常用应用与 AI Agent 工具分身规则，支持通过 `~/ATBClone/recipes/` 本地优先级覆盖自定义规则。
+- 📑 **规则引擎 (Recipe Engine)**：内置 34+ 常用应用与 AI Agent 工具分身规则，支持通过 `~/ATBClone/recipes/` 本地优先级覆盖自定义规则。
 - 🪄 **交互式向导 (Interactive Wizard)**：全流程引导式 CLI，支持终端拖拽 `.app` 路径、自动命名递增、自定义数据目录与快捷代理配置。
 - 🔄 **生命周期管理**：查看已有分身（`list`）、主应用升级后一键重克隆并保留用户数据（`update`）、安全删除分身（`remove` 支持 `--with-data` / `--keep-data` 与交互确认）。
 - 🛡️ **安全与提权机制**：默认克隆至 `~/ATBClone/Apps` 无需 root/sudo 权限；如需写入系统级 `/Applications` 采用原生单次 `osascript` 授权提权；严格使用 `shlex.quote` 保证路径转义安全。
@@ -61,7 +61,7 @@ macOS 原生桌面图形客户端提供直观、全功能的应用分身管理�
    - 自动匹配内置规则或动态触发深度架构探测。
    - 可视化自定义分身名称、显示标题、独立数据目录（如外接移动硬盘）以及 HTTP/SOCKS5 专属代理配置。
 3. **内置规则库 (Recipe Library)**：
-   - 分类浏览内置的 33+ 热门应用规则（微信、QQ、Chrome、Cursor、ChatGPT、Claude 等），查看沙盒剥离与隔离策略。
+   - 分类浏览内置的 34+ 热门应用规则（微信、QQ、Chrome、Cursor、ChatGPT、Claude 等），查看沙盒剥离与隔离策略。
 4. **应用深度探测器 (App Prober)**：
    - 可视化检测任意未知应用的 Mach-O 架构、Frameworks 与沙盒权限，一键生成专属分身规则。
 5. **系统健康自检 (Doctor)**：
@@ -282,6 +282,7 @@ atbclone --version
 | | Telegram (原生 Swift) | `ru.keepcoder.Telegram` | Hard Clone | `cocoa` | ✔ |
 | | Telegram Desktop | `org.telegram.desktop` | Hard Clone | `generic` | ✔ |
 | | LINE | `jp.naver.line.mac` | Hard Clone | `cocoa` | ✔ |
+| | KakaoTalk | `com.kakao.KakaoTalkMac` | Hard Clone | `cocoa` | ✔ |
 | | Slack | `com.tinyspeck.slackmacgap` | Hard Clone | `electron` | ✔ |
 | | Discord | `com.hnc.Discord` | Hard Clone | `electron` | ✔ |
 | | Skype | `com.skype.skype` | Hard Clone | `electron` | ✔ |
@@ -308,6 +309,8 @@ atbclone --version
 | | VS Code | `com.microsoft.VSCode` | Soft Clone | `electron` | — |
 | | Android Studio | `com.google.android.studio` | Hard Clone | `generic` | ✔ |
 | | Zed | `dev.zed.Zed` | Soft Clone | `generic` | — |
+
+**KakaoTalk 验证范围：** 已验证与原应用同时运行及通知功能。分身登录、不同账号之间的数据隔离，以及重启分身后保持登录状态尚未验证。
 
 ---
 

--- a/Readme_zh.md
+++ b/Readme_zh.md
@@ -430,7 +430,7 @@ src/atbclone/
 │   └── views/            # GUI 视图 (仪表盘、规则库、探测器、自检、设置、日志)
 ├── executor/             # 底层执行器 (Direct Subprocess / AppleScript 提权)
 │   └── runner.py
-└── recipes/              # 规则模型、加载器与 33 个内置规则
+└── recipes/              # 规则模型、加载器与 34 个内置规则
     ├── builtin/          # 内置 YAML 规则
     ├── loader.py         # 规则匹配与优先级加载
     └── models.py         # Pydantic 校验模型

--- a/src/atbclone/recipes/builtin/com.kakao.KakaoTalkMac.yaml
+++ b/src/atbclone/recipes/builtin/com.kakao.KakaoTalkMac.yaml
@@ -1,0 +1,9 @@
+bundle_id: com.kakao.KakaoTalkMac
+app_name: KakaoTalk
+strategy: hard_clone
+app_type: cocoa
+strip_sandbox: true
+injection_strategy: auto
+environment_injection:
+  HOME: '{{ATB_DATA_DIR}}/Home'
+  TMPDIR: '{{ATB_DATA_DIR}}/Tmp'

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -217,6 +217,24 @@ def test_load_builtin_wework(monkeypatch, tmp_path):
     assert "Library/Keychains" in recipe.symlink_whitelist
 
 
+def test_load_builtin_kakaotalk(monkeypatch, tmp_path):
+    monkeypatch.setattr(RecipeLoader, "LOCAL_DIR", tmp_path)
+    recipe = RecipeLoader.get("com.kakao.KakaoTalkMac")
+    assert recipe is not None
+    assert recipe.bundle_id == "com.kakao.KakaoTalkMac"
+    assert recipe.app_name == "KakaoTalk"
+    assert recipe.strategy == "hard_clone"
+    assert recipe.app_type == "cocoa"
+    assert recipe.strip_sandbox is True
+    assert recipe.injection_strategy == "auto"
+    assert recipe.environment_injection == {
+        "HOME": "{{ATB_DATA_DIR}}/Home",
+        "TMPDIR": "{{ATB_DATA_DIR}}/Tmp",
+    }
+    assert recipe.proxy.enabled is False
+    assert recipe.launch_args == []
+
+
 def test_load_builtin_chatgpt():
     recipe = RecipeLoader.match("com.openai.codex")
     assert recipe is not None
@@ -322,6 +340,7 @@ def test_all_builtin_recipes_valid(monkeypatch, tmp_path):
         "ru.keepcoder.Telegram": ("Telegram", "hard_clone", True),
         "org.telegram.desktop": ("Telegram Desktop", "hard_clone", True),
         "jp.naver.line.mac": ("LINE", "hard_clone", True),
+        "com.kakao.KakaoTalkMac": ("KakaoTalk", "hard_clone", True),
         "com.tinyspeck.slackmacgap": ("Slack", "hard_clone", True),
         "com.hnc.Discord": ("Discord", "hard_clone", True),
         "com.skype.skype": ("Skype", "hard_clone", True),

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -218,6 +218,7 @@ def test_load_builtin_wework(monkeypatch, tmp_path):
 
 
 def test_load_builtin_kakaotalk(monkeypatch, tmp_path):
+    """Load the built-in KakaoTalk settings without relying on local overrides."""
     monkeypatch.setattr(RecipeLoader, "LOCAL_DIR", tmp_path)
     recipe = RecipeLoader.get("com.kakao.KakaoTalkMac")
     assert recipe is not None


### PR DESCRIPTION
## 说明

KakaoTalk 是韩国常用的即时通讯应用。这次为其 macOS 客户端补充了内置分身规则，采用本机创建 `KakaoTalk2` 时使用的配置。

- 为 `com.kakao.KakaoTalkMac` 添加内置规则，沿用现有的 `hard_clone` / `cocoa` 流程，移除沙盒限制，通过 `HOME` 和 `TMPDIR` 指定分身数据目录，注入策略保持 `auto`。
- 添加规则加载测试，并将 KakaoTalk 纳入全部内置规则的校验。
- 更新中英文 README 的应用列表、规则数量（34+）和验证说明。

## 变更类型

- [ ] 问题修复
- [x] 新功能
- [ ] 破坏性变更
- [x] 文档更新

## 环境信息

- macOS 26.6.2，Apple Silicon（arm64）
- KakaoTalk 26.7.0（1194）
- ATBClone 1.5.0
- 自动化测试：Python 3.12.14，独立虚拟环境，安装 `.[dev,gui]`

## 验证情况

已确认原应用和 `KakaoTalk2` 可以同时运行，通知也正常。创建分身时使用的是 `hard_clone`、`auto` 注入，代理关闭。分身记录和注入库显示，这次 `auto` 实际选择了 `dylib`。

目前只有一个 KakaoTalk 账号，暂时还没测试分身登录、不同账号的数据隔离，以及重启分身后能否保持登录。中英文 README 里也注明了这些尚未验证的部分。

本地测试结果：

- `PYTHONPATH=src:. python -m pytest tests/test_recipes.py -q --tb=short`：31 passed。
- `PYTHONPATH=src:. python -m pytest tests/ -q --tb=short --durations=10`：555 passed，包含 GUI 测试。
- 新增规则与本机 `AppProber.probe('/Applications/KakaoTalk.app')` 的完整结果一致。
- `git diff --check`：通过。

## 检查清单

- [x] 遵循现有规则格式和代码风格。
- [x] 已在本地运行完整测试套件，全部通过。
- [x] 现有克隆引擎及 GUI 自动化测试通过。
- [x] 新增功能包含对应测试。
- [x] PR 标题使用 Conventional Commit 格式。

## 作者 / Agent 环境披露

- **编写方式：** AI 辅助编写，应用的手动验证由我完成。
- **环境：** GPT-6 / Codex 桌面应用；桌面应用版本未记录。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in KakaoTalk Mac recipe for creating isolated app clones with automatic setup and separate data locations.
* **Documentation**
  * Updated the English and Chinese documentation to include KakaoTalk and reflect the increase to 34+ built-in recipes.
  * Added verification notes covering concurrent runs and notifications, while clarifying that multi-account login, data isolation, and login persistence after restart are not yet verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
