### PR TITLE
fix(ci): 修复 build_cli.sh 中 NOTARIZE_ARGS 空数组展开报错

### DIFF
--- a/scripts/build_cli.sh
+++ b/scripts/build_cli.sh
@@ -279,5 +279,9 @@ if [[ "${DO_NOTARIZE}" -eq 1 ]]; then
     if [[ -n "${NOTARIZE_PROFILE}" ]]; then
         NOTARIZE_ARGS+=("--profile" "${NOTARIZE_PROFILE}")
     fi
-    bash scripts/notarize.sh "${NOTARIZE_ARGS[@]}" dist/ATBCloneCli
+    if [[ ${#NOTARIZE_ARGS[@]} -gt 0 ]]; then
+        bash scripts/notarize.sh "${NOTARIZE_ARGS[@]}" dist/ATBCloneCli
+    else
+        bash scripts/notarize.sh dist/ATBCloneCli
+    fi
 fi

--- a/scripts/build_release_packages.sh
+++ b/scripts/build_release_packages.sh
@@ -164,7 +164,11 @@ echo ""
 echo "======================================================"
 echo "  [1/2] Building ATBCloneCli Binary..."
 echo "======================================================"
-bash scripts/build_cli.sh "${CLI_ARGS[@]}"
+if [[ ${#CLI_ARGS[@]} -gt 0 ]]; then
+    bash scripts/build_cli.sh "${CLI_ARGS[@]}"
+else
+    bash scripts/build_cli.sh
+fi
 
 CLI_BIN="dist/ATBCloneCli"
 if [[ ! -f "${CLI_BIN}" || ! -x "${CLI_BIN}" ]]; then
@@ -191,7 +195,11 @@ echo ""
 echo "======================================================"
 echo "  [2/2] Building ATBClone GUI DMG..."
 echo "======================================================"
-bash scripts/build_gui.sh "${GUI_ARGS[@]}"
+if [[ ${#GUI_ARGS[@]} -gt 0 ]]; then
+    bash scripts/build_gui.sh "${GUI_ARGS[@]}"
+else
+    bash scripts/build_gui.sh
+fi
 
 # Locate produced DMG
 PRODUCED_DMG=""

--- a/tests/test_build_script.py
+++ b/tests/test_build_script.py
@@ -299,4 +299,12 @@ def test_release_workflow_syntax_and_structure():
     assert "build_release_packages.sh" in workflow_text
 
 
+def test_build_cli_notarize_args_guard():
+    root = Path(__file__).parent.parent
+    script = root / "scripts" / "build_cli.sh"
+    content = script.read_text(encoding="utf-8")
+    assert "${#NOTARIZE_ARGS[@]}" in content
+
+
+
 


### PR DESCRIPTION
## 修复内容
- 修复 `scripts/build_cli.sh` 在 `set -u` 下因 `NOTARIZE_ARGS` 为空数组展开引发的 `unbound variable` 错误
- 对 `scripts/build_release_packages.sh` 中 `CLI_ARGS` 和 `GUI_ARGS` 增加相同的非空检查保护
- 增加对应单测覆盖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release builds so notarization works correctly whether or not a notarization profile is configured.
  - Updated package creation to handle builds with no additional command-line arguments.

- **Tests**
  - Added coverage to verify correct handling of optional notarization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->